### PR TITLE
Feat/4 seperate theme styles into custom andd layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Front-end for a PlaceCal instance, an online community hub.
 ### To use this template
 
 - [ ] Copy `.env.example` to `.env` and change `CANONICAL_URL`, `JOIN_US_FUNCTION_URL` and `PARTNERSHIP_TAG_LIST`
-- [ ] Edit `elm-pages.config.mjs` with your site's meta information
+- [ ] Edit `elm-pages.config.mjs` to add scripts fonts or stylesheets to you the html `<head>` of your site's template
 - [ ] Edit the markdown in `theme/content` to generate your About and Privacy information
-- [ ] Edit `theme/Copy/Text` to generate your UI & SEO information
+- [ ] Edit `theme/Copy/Text` to generate your UI & SEO text
 - [ ] Add your images, like logos and background to `public/images`
 - [ ] Edit the reset and core css styles like fonts in `public/css`
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Front-end for a PlaceCal instance, an online community hub.
 -  Staging url: 
 -  Production URL:
 
+### To use this template
+
+- [ ] Copy `.env.example` to `.env` and change `CANONICAL_URL`, `JOIN_US_FUNCTION_URL` and `PARTNERSHIP_TAG_LIST`
+- [ ] Edit `elm-pages.config.mjs` with your site's meta information
+- [ ] Edit the markdown in `theme/content` to generate your About and Privacy information
+- [ ] Edit `theme/Copy/Text` to generate your UI & SEO information
+- [ ] Add your images, like logos and background to `public/images`
+- [ ] Edit the reset and core css styles like fonts in `public/css`
+
+
 # Development
 
 ## Prerequisites
@@ -61,6 +71,8 @@ We're using [elm-test-rs](https://github.com/mpizenberg/elm-test-rs) to run [elm
   - `src/Data/PlaceCal` contains code for fetching, caching and decoding data from PlaceCal
   - `src/Helpers/` contains utility code (e.g. for handling dates)
   - `src/Theme/` contains view code like templates and shared styling
+- `theme/*` contains stuff specific to your site
+- `public/*` contains static files to be copied direct to build like image assets and css
 - `tests/*` contains test files
 
 ### Pages
@@ -73,13 +85,6 @@ We're using [elm-test-rs](https://github.com/mpizenberg/elm-test-rs) to run [elm
 ### Styling & layouts
 
 - We are using [elm-css](https://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Css) for styling
-
-### Customisable content and styles
-
-- `theme/*` contains the files with the content and theme information specific to your site
-- UI & SEO meta copy are in `theme/Copy/Text.elm`
-- About and Privacy pages are generated from markdown in `theme/content/`
-- `public/*` contains static files to be copied direct to build like image assets and css
 
 ## Deployment
 

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -20,8 +20,8 @@ import Html.Styled
 import PagesMsg
 import RouteBuilder
 import Shared
+import Skin.Global
 import Task
-import Theme.Global
 import Theme.Page.Events
 import Theme.Page.Partner
 import Theme.PageTemplate
@@ -234,7 +234,7 @@ view app _ model =
                         , events = eventsFromPartnerId aPartner.id app.data.events
                         }
                     )
-            , outerContent = Just (Theme.Global.viewBackButton (Helpers.TransRoutes.toAbsoluteUrl Partners) (t BackToPartnersLinkText))
+            , outerContent = Just (Skin.Global.viewBackButton (Helpers.TransRoutes.toAbsoluteUrl Partners) (t BackToPartnersLinkText))
             }
             |> Html.Styled.map PagesMsg.fromMsg
         ]

--- a/app/Shared.elm
+++ b/app/Shared.elm
@@ -15,7 +15,8 @@ import Pages.Flags
 import Pages.PageUrl exposing (PageUrl)
 import Route exposing (Route)
 import SharedTemplate exposing (SharedTemplate)
-import Theme.Global
+import Skin.Global exposing (globalStyles)
+import Theme.GlobalLayout exposing (containerPage)
 import Theme.PageFooter exposing (viewPageFooter)
 import Theme.PageHeader exposing (viewPageHeader)
 import Time
@@ -244,8 +245,8 @@ view :
 view sharedData page model toMsg pageView =
     { body =
         [ Html.Styled.toUnstyled
-            (Theme.Global.containerPage pageView.title
-                [ Theme.Global.globalStyles
+            (containerPage pageView.title
+                [ globalStyles
                 , viewPageHeader page
                     { showMobileMenu = model.showMobileMenu }
                     |> Html.Styled.map toMsg

--- a/app/Site.elm
+++ b/app/Site.elm
@@ -9,7 +9,7 @@ import Pages.Manifest as Manifest
 import Pages.Url
 import Route
 import SiteConfig exposing (SiteConfig)
-import Theme.Global
+import Skin.Global
 import UrlPath
 
 
@@ -53,8 +53,8 @@ manifest =
               }
             ]
         }
-        |> Manifest.withBackgroundColor Theme.Global.darkBlueRgbColor
-        |> Manifest.withThemeColor Theme.Global.pinkRgbColor
+        |> Manifest.withBackgroundColor Skin.Global.darkBlueRgbColor
+        |> Manifest.withThemeColor Skin.Global.pinkRgbColor
 
 
 pathFromString srcString =

--- a/src/Theme/GlobalLayout.elm
+++ b/src/Theme/GlobalLayout.elm
@@ -1,0 +1,249 @@
+module Theme.GlobalLayout exposing (backButtonStyle, backgroundColorTransition, baseButtonStyle, borderTransition, buttonFloatingWrapperStyle, colorTransition, containerPage, contentContainerStyle, mapImage, mapImageMulti, maxMobile, maxTabletPortrait, screenReaderOnly, withMediaCanHover, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+
+import Color
+import Css exposing (Color, Style, absolute, active, alignItems, auto, backgroundColor, backgroundImage, backgroundRepeat, backgroundSize, batch, block, borderBottomColor, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderRadius, borderStyle, borderWidth, bottom, boxSizing, calc, center, color, cursor, display, displayFlex, em, firstChild, fitContent, flexDirection, focus, fontFamilies, fontSize, fontStyle, fontWeight, height, hex, hidden, hover, inlineBlock, int, italic, justifyContent, left, letterSpacing, lineHeight, margin, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxContent, maxWidth, minus, none, outline, overflow, padding, padding2, padding4, paddingBottom, paddingLeft, paddingRight, pct, pointer, position, property, px, relative, rem, repeat, row, sansSerif, solid, textAlign, textDecoration, textTransform, top, uppercase, url, width, zero)
+import Css.Global exposing (adjacentSiblings, descendants, global, typeSelector)
+import Css.Media as Media exposing (fine, only, screen, withMedia)
+import Css.Transitions exposing (Transition, linear, transition)
+import Html.Styled exposing (Html, a, div, img, input, label, p, text)
+import Html.Styled.Attributes exposing (alt, css, for, href, id, src, type_)
+import Html.Styled.Events exposing (onCheck)
+
+
+
+-- Breakpoints
+
+
+maxMobile : Float
+maxMobile =
+    600
+
+
+withMediaMobileOnly : List Style -> Style
+withMediaMobileOnly =
+    withMedia [ only screen [ Media.maxWidth (px (maxMobile - 1)) ] ]
+
+
+withMediaTabletPortraitUp : List Style -> Style
+withMediaTabletPortraitUp =
+    withMedia [ only screen [ Media.minWidth (px maxMobile) ] ]
+
+
+maxTabletPortrait : Float
+maxTabletPortrait =
+    900
+
+
+withMediaTabletLandscapeUp : List Style -> Style
+withMediaTabletLandscapeUp =
+    withMedia [ only screen [ Media.minWidth (px maxTabletPortrait) ] ]
+
+
+maxTabletLandscape : Float
+maxTabletLandscape =
+    1200
+
+
+withMediaSmallDesktopUp : List Style -> Style
+withMediaSmallDesktopUp =
+    withMedia [ only screen [ Media.minWidth (px maxTabletLandscape) ] ]
+
+
+maxSmallDesktop : Float
+maxSmallDesktop =
+    1500
+
+
+withMediaMediumDesktopUp : List Style -> Style
+withMediaMediumDesktopUp =
+    withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
+
+
+withMediaCanHover : List Style -> Style
+withMediaCanHover =
+    withMedia [ only screen [ Media.hover Media.canHover, Media.pointer fine ] ]
+
+
+
+-- Transitions
+
+
+borderTransition : Transition
+borderTransition =
+    Css.Transitions.border3 500 0 linear
+
+
+colorTransition : Transition
+colorTransition =
+    Css.Transitions.color3 500 0 linear
+
+
+backgroundColorTransition : Transition
+backgroundColorTransition =
+    Css.Transitions.backgroundColor3 500 0 linear
+
+
+
+-- Buttons (styles)
+
+
+buttonFloatingWrapperStyle : Style
+buttonFloatingWrapperStyle =
+    batch
+        [ margin2 (rem 1) auto
+        , display block
+        , position absolute
+        , bottom (rem -2)
+        , textAlign center
+        , width (pct 100)
+        ]
+
+
+baseButtonStyle : Style
+baseButtonStyle =
+    batch
+        [ textDecoration none
+        , padding4 (rem 0.375) (rem 1.25) (rem 0.5) (rem 1.25)
+        , borderRadius (rem 0.3)
+        , fontWeight (int 600)
+        , fontSize (rem 1.2)
+        , display block
+        , textAlign center
+        , maxWidth maxContent
+        , margin2 (rem 0) auto
+        , borderWidth (rem 0.2)
+        , borderStyle solid
+        , transition [ backgroundColorTransition, borderTransition, colorTransition ]
+        ]
+
+
+backButtonStyle : Style
+backButtonStyle =
+    batch
+        [ textAlign center
+        , margin4 (rem 3) (rem 2) (rem 0) (rem 2)
+        ]
+
+
+
+-- Page Elements
+
+
+contentContainerStyle : Style
+contentContainerStyle =
+    batch
+        [ margin (rem 0.75)
+        , withMediaMediumDesktopUp [ margin (rem 1.5) ]
+        , withMediaTabletPortraitUp [ margin2 (rem 0) (rem 2) ]
+        ]
+
+
+screenReaderOnly : Style
+screenReaderOnly =
+    batch
+        [ position absolute
+        , left (px -10000)
+        , top auto
+        , width (px 1)
+        , height (px 1)
+        , overflow hidden
+        ]
+
+
+containerPage : String -> List (Html msg) -> Html msg
+containerPage pageTitle content =
+    div
+        [ id ("page-" ++ generateId pageTitle)
+        , css [ margin2 zero auto, width (pct 100), overflow hidden ]
+        ]
+        content
+
+
+
+-- Helpers
+
+
+generateId : String -> String
+generateId input =
+    String.trim (String.replace " " "-" (String.toLower input))
+
+
+
+-- Map
+
+
+mapImageMulti :
+    String
+    -> List { latitude : Maybe String, longitude : Maybe String }
+    -> Html msg
+mapImageMulti altText markerList =
+    img
+        [ src
+            ("https://api.mapbox.com/styles/v1/studiosquid/cl082tq5a001o14mgaatx9fze/static/"
+                ++ String.join ","
+                    (List.map (\marker -> "pin-l+ffffff(" ++ marker.longitude ++ "," ++ marker.latitude ++ ")") (removeNullCoords markerList))
+                ++ "/auto/1140x400@2x?access_token=pk.eyJ1Ijoic3R1ZGlvc3F1aWQiLCJhIjoiY2o5bzZmNzhvMWI2dTJ3bnQ1aHFnd3loYSJ9.NC3T07dEr_Aw7wo1O8aF-g"
+            )
+        , alt altText
+        , css [ mapStyle ]
+        ]
+        []
+
+
+mapImage :
+    String
+    -> { latitude : Maybe String, longitude : Maybe String }
+    -> Html msg
+mapImage altText geo =
+    if not (markerHasLatAndLong geo) then
+        text ""
+
+    else
+        mapImageHtml
+            ( altText
+            , maybeLatLongToLatLongWithDefault0 geo
+            )
+
+
+mapImageHtml : ( String, { latitude : String, longitude : String } ) -> Html msg
+mapImageHtml ( altText, geo ) =
+    img
+        [ src ("https://api.mapbox.com/styles/v1/studiosquid/cl082tq5a001o14mgaatx9fze/static/pin-l+ffffff(" ++ geo.longitude ++ "," ++ geo.latitude ++ ")/" ++ geo.longitude ++ "," ++ geo.latitude ++ ",15,0/1140x400@2x?access_token=pk.eyJ1Ijoic3R1ZGlvc3F1aWQiLCJhIjoiY2o5bzZmNzhvMWI2dTJ3bnQ1aHFnd3loYSJ9.NC3T07dEr_Aw7wo1O8aF-g")
+        , alt altText
+        , css [ mapStyle ]
+        ]
+        []
+
+
+removeNullCoords :
+    List { latitude : Maybe String, longitude : Maybe String }
+    -> List { latitude : String, longitude : String }
+removeNullCoords markerList =
+    List.filter (\marker -> markerHasLatAndLong marker) markerList
+        |> List.map maybeLatLongToLatLongWithDefault0
+
+
+markerHasLatAndLong : { latitude : Maybe String, longitude : Maybe String } -> Bool
+markerHasLatAndLong markerData =
+    not (markerData.latitude == Nothing || markerData.longitude == Nothing)
+
+
+maybeLatLongToLatLongWithDefault0 :
+    { latitude : Maybe String, longitude : Maybe String }
+    -> { latitude : String, longitude : String }
+maybeLatLongToLatLongWithDefault0 { latitude, longitude } =
+    -- Return 0, 0 as coords if there is no data
+    { latitude = Maybe.withDefault "0" latitude
+    , longitude = Maybe.withDefault "0" longitude
+    }
+
+
+mapStyle : Style
+mapStyle =
+    batch
+        [ height (px 318)
+        , width (pct 100)
+        , property "object-fit" "cover"
+        , withMediaTabletLandscapeUp [ height (px 400) ]
+        , borderRadius (rem 0.3)
+        ]

--- a/src/Theme/Logo.elm
+++ b/src/Theme/Logo.elm
@@ -6,7 +6,7 @@ import Css.Transitions exposing (transition)
 import Html.Styled exposing (Html)
 import Svg.Styled exposing (defs, g, path, svg, text, title)
 import Svg.Styled.Attributes exposing (clipRule, d, fill, height, id, transform, viewBox, width, xmlSpace)
-import Theme.Global exposing (withMediaCanHover)
+import Theme.GlobalLayout exposing (withMediaCanHover)
 
 
 view : Html msg

--- a/src/Theme/Page/About.elm
+++ b/src/Theme/Page/About.elm
@@ -5,7 +5,8 @@ import Css.Global exposing (descendants, typeSelector)
 import Html.Styled exposing (Html, a, div, h3, h4, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import Markdown.Block
-import Theme.Global exposing (buttonFloatingWrapperStyle, contentContainerStyle, contentWrapperStyle, introTextLargeStyle, normalFirstParagraphStyle, smallFloatingTitleStyle, textBoxPinkStyle, whiteButtonStyle, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (contentWrapperStyle, introTextLargeStyle, normalFirstParagraphStyle, smallFloatingTitleStyle, textBoxPinkStyle, whiteButtonStyle)
+import Theme.GlobalLayout exposing (buttonFloatingWrapperStyle, contentContainerStyle, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate
 import Theme.TransMarkdown
 

--- a/src/Theme/Page/Event.elm
+++ b/src/Theme/Page/Event.elm
@@ -8,7 +8,8 @@ import Helpers.TransDate
 import Helpers.TransRoutes
 import Html.Styled exposing (Html, a, div, h4, hr, p, section, text, time)
 import Html.Styled.Attributes exposing (css, href, target)
-import Theme.Global exposing (linkStyle, normalFirstParagraphStyle, pink, smallInlineTitleStyle, withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (hrStyle, linkStyle, mapImage, normalFirstParagraphStyle, pink, smallInlineTitleStyle, viewBackButton)
+import Theme.GlobalLayout exposing (withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.TransMarkdown
 
 
@@ -16,15 +17,15 @@ viewEventInfo : Data.PlaceCal.Events.Event -> Html msg
 viewEventInfo event =
     div []
         [ viewDateTimeSection event
-        , hr [ css [ Theme.Global.hrStyle ] ] []
+        , hr [ css [ hrStyle ] ] []
         , viewInfoSection event
-        , hr [ css [ Theme.Global.hrStyle, marginTop (rem 2.5) ] ] []
+        , hr [ css [ hrStyle, marginTop (rem 2.5) ] ] []
         , viewAddressSection event
         , case event.maybeGeo of
             Just geo ->
                 div [ css [ mapContainerStyle ] ]
                     [ p []
-                        [ Theme.Global.mapImage
+                        [ mapImage
                             (t (MapImageAltText event.name))
                             { latitude = geo.latitude, longitude = geo.longitude }
                         ]
@@ -74,7 +75,7 @@ viewAddressSection event =
                           else
                             text ""
                         , if contact.email /= "" then
-                            p [ css [ contactItemStyle ] ] [ a [ href ("mailto:" ++ contact.email), css [ Theme.Global.linkStyle ] ] [ text contact.email ] ]
+                            p [ css [ contactItemStyle ] ] [ a [ href ("mailto:" ++ contact.email), css [ linkStyle ] ] [ text contact.email ] ]
 
                           else
                             text ""
@@ -86,7 +87,7 @@ viewAddressSection event =
                 Just url ->
                     if isValidUrl url then
                         p [ css [ contactItemStyle ] ]
-                            [ a [ href url, target "_blank", css [ Theme.Global.linkStyle ] ]
+                            [ a [ href url, target "_blank", css [ linkStyle ] ]
                                 [ text (Copy.Text.urlToDisplay url) ]
                             ]
 
@@ -125,10 +126,10 @@ viewAddressSection event =
 viewButtons : Data.PlaceCal.Events.Event -> Html msg
 viewButtons event =
     section [ css [ buttonsStyle ] ]
-        [ Theme.Global.viewBackButton
+        [ viewBackButton
             (Helpers.TransRoutes.toAbsoluteUrl (Helpers.TransRoutes.Partner event.partner.id) ++ "#events")
             (t (BackToPartnerEventsLinkText event.partner.name))
-        , Theme.Global.viewBackButton
+        , viewBackButton
             (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)
             (t BackToEventsLinkText)
         ]
@@ -140,8 +141,8 @@ publisherUrlSection event =
         Just publisherUrl ->
             if isValidUrl publisherUrl then
                 div [ css [ publisherSectionStyle ] ]
-                    [ hr [ css [ Theme.Global.hrStyle, marginTop (rem 2.5) ] ] []
-                    , a [ href publisherUrl, css [ Theme.Global.linkStyle ] ] [ text (t (EventVisitPublisherUrlText event.partner.name)) ]
+                    [ hr [ css [ hrStyle, marginTop (rem 2.5) ] ] []
+                    , a [ href publisherUrl, css [ linkStyle ] ] [ text (t (EventVisitPublisherUrlText event.partner.name)) ]
                     ]
 
             else
@@ -233,7 +234,7 @@ addressItemStyle =
 addressItemTitleStyle : Style
 addressItemTitleStyle =
     batch
-        [ color Theme.Global.pink
+        [ color pink
         , smallInlineTitleStyle
         , withMediaTabletPortraitUp [ marginTop (rem 1) ]
         ]

--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -12,7 +12,8 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, button, div, h4, li, p, section, span, text, time, ul)
 import Html.Styled.Attributes exposing (css, href)
 import Html.Styled.Events
-import Theme.Global exposing (borderTransition, colorTransition, darkBlue, introTextLargeStyle, pink, white, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (darkBlue, introTextLargeStyle, pink, white)
+import Theme.GlobalLayout exposing (borderTransition, colorTransition, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Paginator exposing (buttonWidthFullWidth, buttonWidthMobile, buttonWidthTablet, paginationButtonStyle)
 import Theme.RegionSelector
 import Time

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -9,7 +9,15 @@ import Data.PlaceCal.Partners
 import Helpers.TransRoutes
 import Html.Styled exposing (Html, a, div, h1, h2, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src)
-import Theme.Global
+import Skin.Global exposing (darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, smallFloatingTitleStyle, whiteButtonStyle)
+import Theme.GlobalLayout
+    exposing
+        ( buttonFloatingWrapperStyle
+        , withMediaMediumDesktopUp
+        , withMediaSmallDesktopUp
+        , withMediaTabletLandscapeUp
+        , withMediaTabletPortraitUp
+        )
 import Theme.Page.Events exposing (Msg, fromRegionSelectorMsg)
 import Theme.Page.News
 import Theme.Paginator
@@ -39,7 +47,7 @@ view sharedData localModel =
 
 viewIntro : String -> String -> String -> Html msg
 viewIntro introTitle introMsg eventButtonText =
-    section [ css [ sectionStyle, Theme.Global.pinkBackgroundStyle, introSectionStyle ] ]
+    section [ css [ sectionStyle, pinkBackgroundStyle, introSectionStyle ] ]
         [ h1 [ css [ logoStyle ] ]
             [ img
                 [ src "/images/logos/tdd_logo_with_strapline.svg"
@@ -50,10 +58,10 @@ viewIntro introTitle introMsg eventButtonText =
             ]
         , h2 [ css [ sectionSubtitleStyle ] ] [ text introTitle ]
         , p [ css [ sectionTextStyle ] ] [ text introMsg ]
-        , p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
+        , p [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)
-                , css [ Theme.Global.whiteButtonStyle ]
+                , css [ whiteButtonStyle ]
                 ]
                 [ text eventButtonText ]
             ]
@@ -62,8 +70,8 @@ viewIntro introTitle introMsg eventButtonText =
 
 viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
 viewFeatured fromTime eventList regionId =
-    section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
-        [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
+    section [ css [ sectionStyle, darkBlueBackgroundStyle, eventsSectionStyle ] ]
+        [ h2 [ css [ smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
         , if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
             Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
 
@@ -76,10 +84,10 @@ viewFeatured fromTime eventList regionId =
 
 viewAllEventsButton : Html msg
 viewAllEventsButton =
-    p [ css [ Theme.Global.buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
+    p [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
         [ a
             [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)
-            , css [ Theme.Global.pinkButtonOnDarkBackgroundStyle ]
+            , css [ pinkButtonOnDarkBackgroundStyle ]
             ]
             [ text (t IndexFeaturedButtonText) ]
         ]
@@ -87,18 +95,18 @@ viewAllEventsButton =
 
 viewLatestNews : Maybe Data.PlaceCal.Articles.Article -> String -> String -> Html msg
 viewLatestNews maybeNewsItem title buttonText =
-    section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, newsSectionStyle ] ]
-        [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text title ]
+    section [ css [ sectionStyle, darkBlueBackgroundStyle, newsSectionStyle ] ]
+        [ h2 [ css [ smallFloatingTitleStyle ] ] [ text title ]
         , case maybeNewsItem of
             Just news ->
                 Theme.Page.News.viewNewsArticle news
 
             Nothing ->
                 text ""
-        , p [ css [ Theme.Global.buttonFloatingWrapperStyle, bottom (rem -6), width (calc (pct 100) minus (rem 2)) ] ]
+        , p [ css [ buttonFloatingWrapperStyle, bottom (rem -6), width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.News)
-                , css [ Theme.Global.darkBlueButtonStyle ]
+                , css [ darkBlueButtonStyle ]
                 ]
                 [ text buttonText ]
             ]
@@ -109,9 +117,9 @@ pageWrapperStyle : Style
 pageWrapperStyle =
     batch
         [ margin2 (rem 0) (rem 0.75)
-        , Theme.Global.withMediaSmallDesktopUp [ margin2 (rem 0) (rem 6) ]
-        , Theme.Global.withMediaTabletLandscapeUp [ margin2 (rem 0) (rem 5) ]
-        , Theme.Global.withMediaTabletPortraitUp [ margin2 (rem 0) (rem 1.5) ]
+        , withMediaSmallDesktopUp [ margin2 (rem 0) (rem 6) ]
+        , withMediaTabletLandscapeUp [ margin2 (rem 0) (rem 5) ]
+        , withMediaTabletPortraitUp [ margin2 (rem 0) (rem 1.5) ]
         ]
 
 
@@ -119,13 +127,13 @@ logoStyle : Style
 logoStyle =
     batch
         [ display none
-        , Theme.Global.withMediaMediumDesktopUp
+        , withMediaMediumDesktopUp
             [ top (px -750) ]
-        , Theme.Global.withMediaSmallDesktopUp
+        , withMediaSmallDesktopUp
             [ top (px -575) ]
-        , Theme.Global.withMediaTabletLandscapeUp
+        , withMediaTabletLandscapeUp
             [ top (px -425) ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaTabletPortraitUp
             [ display block
             , position absolute
             , width (pct 100)
@@ -140,9 +148,9 @@ logoImageStyle =
     batch
         [ width (px 268)
         , display inlineBlock
-        , Theme.Global.withMediaMediumDesktopUp [ width (px 527) ]
-        , Theme.Global.withMediaSmallDesktopUp [ width (px 381) ]
-        , Theme.Global.withMediaTabletLandscapeUp [ width (px 305) ]
+        , withMediaMediumDesktopUp [ width (px 527) ]
+        , withMediaSmallDesktopUp [ width (px 381) ]
+        , withMediaTabletLandscapeUp [ width (px 305) ]
         ]
 
 
@@ -163,31 +171,31 @@ sectionStyle =
             , zIndex (int -1)
             , backgroundRepeat noRepeat
             , margin2 (rem 0) (rem -1.75)
-            , Theme.Global.withMediaMediumDesktopUp
+            , withMediaMediumDesktopUp
                 [ backgroundSize (px 1920)
                 , margin2 (rem 0) (calc (vw -50) minus (px -475))
                 ]
-            , Theme.Global.withMediaSmallDesktopUp
+            , withMediaSmallDesktopUp
                 [ backgroundSize (px 1366)
                 , margin2 (rem 0) (rem -14)
                 ]
-            , Theme.Global.withMediaTabletLandscapeUp
+            , withMediaTabletLandscapeUp
                 [ backgroundSize (px 1200)
                 , margin2 (rem 0) (rem -6)
                 ]
-            , Theme.Global.withMediaTabletPortraitUp
+            , withMediaTabletPortraitUp
                 [ backgroundSize (px 900)
                 , margin2 (rem 0) (rem -2.5)
                 ]
             ]
-        , Theme.Global.withMediaMediumDesktopUp
+        , withMediaMediumDesktopUp
             [ maxWidth (px 950), marginRight auto, marginLeft auto ]
-        , Theme.Global.withMediaSmallDesktopUp
+        , withMediaSmallDesktopUp
             [ padding4 (rem 3) (rem 1) (rem 3) (rem 1)
             , marginLeft (rem 7)
             , marginRight (rem 7)
             ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaTabletPortraitUp
             [ paddingBottom (rem 3) ]
         ]
 
@@ -202,10 +210,10 @@ sectionSubtitleStyle =
         , fontSize (rem 2.1)
         , lineHeight (em 1.1)
         , fontWeight (int 500)
-        , color Theme.Global.darkBlue
-        , Theme.Global.withMediaSmallDesktopUp
+        , color darkBlue
+        , withMediaSmallDesktopUp
             [ margin2 (rem 0.5) (rem 1) ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaTabletPortraitUp
             [ fontSize (rem 3.2)
             , margin2 (rem 0.5) (rem 4)
             , paddingLeft (rem 0)
@@ -218,10 +226,10 @@ sectionTextStyle : Style
 sectionTextStyle =
     batch
         [ textAlign center
-        , color Theme.Global.darkBlue
-        , Theme.Global.withMediaSmallDesktopUp
+        , color darkBlue
+        , withMediaSmallDesktopUp
             [ margin2 (rem 2) (rem 8) ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaTabletPortraitUp
             [ fontSize (rem 1.2)
             , margin2 (rem 1) (rem 4)
             ]
@@ -236,31 +244,31 @@ introSectionStyle =
             [ backgroundImage (url "/images/illustrations/320px/homepage_1_header.png")
             , height (px 626)
             , top (px -550)
-            , Theme.Global.withMediaMediumDesktopUp
+            , withMediaMediumDesktopUp
                 [ backgroundImage (url "/images/illustrations/1920px/homepage_1_header.png")
                 , height (px 1306)
                 , top (px -1100)
                 ]
-            , Theme.Global.withMediaSmallDesktopUp
+            , withMediaSmallDesktopUp
                 [ backgroundImage (url "/images/illustrations/1366px/homepage_1_header.png")
                 , height (px 1142)
                 , top (px -850)
                 ]
-            , Theme.Global.withMediaTabletLandscapeUp
+            , withMediaTabletLandscapeUp
                 [ backgroundImage (url "/images/illustrations/1024px/homepage_1_header.png")
                 , height (px 792)
                 , top (px -650)
                 ]
-            , Theme.Global.withMediaTabletPortraitUp
+            , withMediaTabletPortraitUp
                 [ backgroundImage (url "/images/illustrations/768px/homepage_1_header.png")
                 , height (px 960)
                 , top (px -900)
                 ]
             ]
-        , Theme.Global.withMediaMediumDesktopUp [ marginTop (px 1000) ]
-        , Theme.Global.withMediaSmallDesktopUp [ marginTop (px 750) ]
-        , Theme.Global.withMediaTabletLandscapeUp [ marginTop (px 550) ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaMediumDesktopUp [ marginTop (px 1000) ]
+        , withMediaSmallDesktopUp [ marginTop (px 750) ]
+        , withMediaTabletLandscapeUp [ marginTop (px 550) ]
+        , withMediaTabletPortraitUp
             [ marginTop (px 820)
             ]
         ]
@@ -274,44 +282,44 @@ eventsSectionStyle =
             [ backgroundImage (url "/images/illustrations/320px/homepage_3.png")
             , height (px 240)
             , top (px -250)
-            , Theme.Global.withMediaMediumDesktopUp
+            , withMediaMediumDesktopUp
                 [ backgroundImage (url "/images/illustrations/1920px/homepage_3.png")
                 , height (px 250)
                 , top (px -220)
                 , important (marginLeft (calc (vw -50) minus (px -575)))
                 , important (marginRight (calc (vw -50) minus (px -575)))
                 ]
-            , Theme.Global.withMediaSmallDesktopUp
+            , withMediaSmallDesktopUp
                 [ backgroundImage (url "/images/illustrations/1366px/homepage_3.png")
                 , height (px 200)
                 , important (marginLeft (rem -7))
                 , important (marginRight (rem -7))
                 , top (px -200)
                 ]
-            , Theme.Global.withMediaTabletLandscapeUp
+            , withMediaTabletLandscapeUp
                 [ backgroundImage (url "/images/illustrations/1024px/homepage_3.png")
                 , height (px 280)
                 , top (px -230)
                 ]
-            , Theme.Global.withMediaTabletPortraitUp
+            , withMediaTabletPortraitUp
                 [ backgroundImage (url "/images/illustrations/768px/homepage_3.png")
                 , height (px 200)
                 , top (px -195)
                 ]
             ]
-        , Theme.Global.withMediaMediumDesktopUp
+        , withMediaMediumDesktopUp
             [ important (maxWidth (px 1150))
             , important (marginLeft auto)
             , important (marginRight auto)
             , marginTop (px 220)
             ]
-        , Theme.Global.withMediaSmallDesktopUp
+        , withMediaSmallDesktopUp
             [ important (marginLeft (rem 0))
             , important (marginRight (rem 0))
             ]
-        , Theme.Global.withMediaTabletLandscapeUp
+        , withMediaTabletLandscapeUp
             [ marginTop (px 150) ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaTabletPortraitUp
             [ marginTop (px 175) ]
         ]
 
@@ -325,22 +333,22 @@ newsSectionStyle =
             [ backgroundImage (url "/images/illustrations/320px/homepage_4.png")
             , height (px 240)
             , top (px -240)
-            , Theme.Global.withMediaMediumDesktopUp
+            , withMediaMediumDesktopUp
                 [ backgroundImage (url "/images/illustrations/1920px/homepage_4.png")
                 , height (px 250)
                 , top (px -250)
                 ]
-            , Theme.Global.withMediaSmallDesktopUp
+            , withMediaSmallDesktopUp
                 [ backgroundImage (url "/images/illustrations/1366px/homepage_4.png")
                 , height (px 237)
                 , top (px -200)
                 ]
-            , Theme.Global.withMediaTabletLandscapeUp
+            , withMediaTabletLandscapeUp
                 [ backgroundImage (url "/images/illustrations/1024px/homepage_4.png")
                 , height (px 280)
                 , top (px -230)
                 ]
-            , Theme.Global.withMediaTabletPortraitUp
+            , withMediaTabletPortraitUp
                 [ backgroundImage (url "/images/illustrations/768px/homepage_4.png")
                 , height (px 200)
                 , top (px -195)
@@ -359,28 +367,28 @@ newsSectionStyle =
             , margin2 (rem 0) (rem -1.75)
             , bottom (px -270)
             , height (px 240)
-            , Theme.Global.withMediaMediumDesktopUp
+            , withMediaMediumDesktopUp
                 [ backgroundSize (px 1920)
                 , backgroundImage (url "/images/illustrations/1920px/homepage_5.png")
                 , margin2 (rem 0) (calc (vw -50) minus (px -475))
                 , height (px 250)
                 , bottom (px -210)
                 ]
-            , Theme.Global.withMediaSmallDesktopUp
+            , withMediaSmallDesktopUp
                 [ backgroundSize (px 1366)
                 , margin2 (rem 0) (rem -14)
                 , backgroundImage (url "/images/illustrations/1366px/homepage_5.png")
                 , height (px 237)
                 , bottom (px -200)
                 ]
-            , Theme.Global.withMediaTabletLandscapeUp
+            , withMediaTabletLandscapeUp
                 [ backgroundSize (px 1200)
                 , margin2 (rem 0) (rem -6)
                 , backgroundImage (url "/images/illustrations/1024px/homepage_5.png")
                 , height (px 280)
                 , bottom (px -220)
                 ]
-            , Theme.Global.withMediaTabletPortraitUp
+            , withMediaTabletPortraitUp
                 [ backgroundImage (url "/images/illustrations/768px/homepage_5.png")
                 , backgroundSize (px 900)
                 , height (px 200)
@@ -388,12 +396,12 @@ newsSectionStyle =
                 , margin2 (rem 0) (rem -2.5)
                 ]
             ]
-        , Theme.Global.withMediaMediumDesktopUp
+        , withMediaMediumDesktopUp
             [ marginBottom (px 230), marginTop (px 220) ]
-        , Theme.Global.withMediaSmallDesktopUp
+        , withMediaSmallDesktopUp
             [ marginBottom (px 200) ]
-        , Theme.Global.withMediaTabletLandscapeUp
+        , withMediaTabletLandscapeUp
             [ marginTop (px 150), marginBottom (px 150) ]
-        , Theme.Global.withMediaTabletPortraitUp
+        , withMediaTabletPortraitUp
             [ marginTop (px 175), marginBottom (px 175), paddingTop (rem 2), important (paddingBottom (rem 4)) ]
         ]

--- a/src/Theme/Page/JoinUs.elm
+++ b/src/Theme/Page/JoinUs.elm
@@ -12,8 +12,9 @@ import Http
 import Json.Encode
 import RouteBuilder
 import Shared
+import Skin.Global exposing (pink, pinkButtonOnDarkBackgroundStyle, textInputErrorStyle, textInputStyle, viewCheckbox, white)
 import Task
-import Theme.Global exposing (pink, pinkButtonOnDarkBackgroundStyle, textInputErrorStyle, textInputStyle, viewCheckbox, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.GlobalLayout exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
 type alias Model =

--- a/src/Theme/Page/News.elm
+++ b/src/Theme/Page/News.elm
@@ -8,7 +8,8 @@ import Helpers.TransDate as TransDate
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, div, h3, img, li, p, section, span, text, time, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
-import Theme.Global exposing (buttonFloatingWrapperStyle, darkBlueBackgroundStyle, linkStyle, pinkButtonOnLightBackgroundStyle, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (darkBlueBackgroundStyle, linkStyle, pinkButtonOnLightBackgroundStyle)
+import Theme.GlobalLayout exposing (buttonFloatingWrapperStyle, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
 viewNewsList : List Data.PlaceCal.Articles.Article -> Html msg

--- a/src/Theme/Page/NewsItem.elm
+++ b/src/Theme/Page/NewsItem.elm
@@ -6,7 +6,7 @@ import Data.PlaceCal.Articles
 import Helpers.TransDate as TransDate
 import Html.Styled exposing (Html, article, div, figure, img, p, span, text, time)
 import Html.Styled.Attributes exposing (alt, css, src)
-import Theme.Global exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.GlobalLayout exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.TransMarkdown as TransMarkdown
 
 

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -7,7 +7,13 @@ import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, a, address, div, h3, hr, p, section, span, text)
 import Html.Styled.Attributes exposing (css, href, id, target)
-import Theme.Global exposing (hrStyle, introTextLargeStyle, linkStyle, normalFirstParagraphStyle, pink, smallInlineTitleStyle, white, withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (hrStyle, introTextLargeStyle, linkStyle, mapImage, normalFirstParagraphStyle, pink, smallInlineTitleStyle, white)
+import Theme.GlobalLayout
+    exposing
+        ( withMediaMediumDesktopUp
+        , withMediaTabletLandscapeUp
+        , withMediaTabletPortraitUp
+        )
 import Theme.Page.Events
 import Theme.Paginator
 import Theme.TransMarkdown
@@ -33,11 +39,11 @@ viewInfo localModel { partner, events } =
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]
-                [ h3 [ css [ contactHeadingStyle, Theme.Global.smallInlineTitleStyle ] ] [ text (t PartnerContactsHeading) ]
+                [ h3 [ css [ contactHeadingStyle, smallInlineTitleStyle ] ] [ text (t PartnerContactsHeading) ]
                 , viewContactDetails partner.maybeUrl partner.maybeContactDetails partner.maybeInstagramUrl
                 ]
             , div [ css [ contactSectionStyle ] ]
-                [ h3 [ css [ contactHeadingStyle, Theme.Global.smallInlineTitleStyle ] ] [ text (t PartnerAddressHeading) ]
+                [ h3 [ css [ contactHeadingStyle, smallInlineTitleStyle ] ] [ text (t PartnerAddressHeading) ]
                 , viewAddress partner.maybeAddress
                 ]
             ]
@@ -47,7 +53,7 @@ viewInfo localModel { partner, events } =
             Just geo ->
                 div [ css [ mapContainerStyle ] ]
                     [ p []
-                        [ Theme.Global.mapImage
+                        [ mapImage
                             (t (MapImageAltText partner.name))
                             { latitude = geo.latitude, longitude = geo.longitude }
                         ]
@@ -232,7 +238,7 @@ contactSectionStyle =
 
 contactHeadingStyle : Style
 contactHeadingStyle =
-    batch [ color Theme.Global.pink ]
+    batch [ color pink ]
 
 
 contactItemStyle : Style

--- a/src/Theme/Page/Partners.elm
+++ b/src/Theme/Page/Partners.elm
@@ -9,7 +9,8 @@ import Data.PlaceCal.Partners
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, div, h3, h4, li, p, section, span, styled, text, ul)
 import Html.Styled.Attributes exposing (css, href)
-import Theme.Global as Theme exposing (darkPurple, pink, purple, white, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (darkPurple, mapImageMulti, pink, purple, white)
+import Theme.GlobalLayout exposing (borderTransition, colorTransition, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.RegionSelector
 
 
@@ -80,7 +81,7 @@ viewMap partnerList =
                     }
     in
     div [ css [ featurePlaceholderStyle ] ]
-        [ Theme.mapImageMulti
+        [ mapImageMulti
             (t PartnersMapAltText)
             (List.filter allowOnlyPartnersWithLocation partnerList
                 |> List.map partnerToGeo
@@ -213,7 +214,7 @@ partnerTopRowStyle =
         , borderBottomWidth (px 2)
         , borderBottomStyle solid
         , withMediaTabletLandscapeUp [ padding2 (rem 0.75) (rem 0) ]
-        , transition [ Theme.borderTransition ]
+        , transition [ borderTransition ]
         ]
 
 
@@ -232,7 +233,7 @@ partnerLink =
     batch
         [ textDecoration none
         , color white
-        , transition [ Theme.colorTransition ]
+        , transition [ colorTransition ]
         ]
 
 
@@ -242,7 +243,7 @@ partnerNameStyle =
         [ fontSize (rem 1.2)
         , fontStyle italic
         , color white
-        , transition [ Theme.colorTransition ]
+        , transition [ colorTransition ]
         , withMediaTabletPortraitUp [ fontSize (rem 1.5) ]
         ]
 

--- a/src/Theme/PageFooter.elm
+++ b/src/Theme/PageFooter.elm
@@ -9,7 +9,8 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, button, div, footer, form, img, input, label, li, nav, p, span, text, ul)
 import Html.Styled.Attributes exposing (action, alt, attribute, css, for, href, id, method, name, placeholder, src, target, type_, value)
 import List exposing (append, concat)
-import Theme.Global exposing (colorTransition, darkBlue, darkPurple, pink, pinkButtonOnDarkBackgroundStyle, smallInlineTitleStyle, textInputStyle, white, withMediaCanHover, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (darkBlue, darkPurple, pink, pinkButtonOnDarkBackgroundStyle, smallInlineTitleStyle, textInputStyle, white)
+import Theme.GlobalLayout exposing (colorTransition, withMediaCanHover, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Logo
 import Time
 

--- a/src/Theme/PageHeader.elm
+++ b/src/Theme/PageHeader.elm
@@ -10,7 +10,8 @@ import Html.Styled.Attributes exposing (attribute, css, href)
 import Html.Styled.Events exposing (onClick)
 import Messages exposing (Msg(..))
 import Route exposing (Route)
-import Theme.Global exposing (darkBlue, pink, screenReaderOnly, white, withMediaCanHover, withMediaTabletPortraitUp)
+import Skin.Global exposing (darkBlue, pink, white)
+import Theme.GlobalLayout exposing (screenReaderOnly, withMediaCanHover, withMediaTabletPortraitUp)
 import Theme.Logo
 import UrlPath exposing (UrlPath)
 

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -10,7 +10,8 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import List exposing (append)
 import Markdown.Block
 import Pages.Url
-import Theme.Global exposing (contentContainerStyle, contentWrapperStyle, introTextLargeStyle, introTextSmallStyle, textBoxInvisibleStyle, textBoxPinkStyle, white, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (contentWrapperStyle, introTextLargeStyle, introTextSmallStyle, textBoxInvisibleStyle, textBoxPinkStyle, white)
+import Theme.GlobalLayout exposing (contentContainerStyle, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
 type alias PageUsingTemplate msg =

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -11,8 +11,9 @@ import Helpers.TransDate as TransDate
 import Html.Styled exposing (Html, button, div, img, li, text, ul)
 import Html.Styled.Attributes exposing (css, id, src)
 import Html.Styled.Events
+import Skin.Global exposing (darkBlue, darkPurple, pink, white)
 import Task exposing (Task)
-import Theme.Global exposing (backgroundColorTransition, borderTransition, colorTransition, darkBlue, darkPurple, pink, white, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.GlobalLayout exposing (backgroundColorTransition, borderTransition, colorTransition, maxMobile, maxTabletPortrait, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Time
 
 
@@ -157,10 +158,10 @@ scrollPagination direction viewportWidth =
                 let
                     scrollXAmount : Float
                     scrollXAmount =
-                        if viewportWidth < Theme.Global.maxMobile then
+                        if viewportWidth < maxMobile then
                             buttonWidthMobile + (buttonMarginMobile * 2)
 
-                        else if viewportWidth < Theme.Global.maxTabletPortrait then
+                        else if viewportWidth < maxTabletPortrait then
                             buttonWidthTablet + (buttonMarginTablet * 2)
 
                         else

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -9,7 +9,8 @@ import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, button, div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events
-import Theme.Global exposing (backgroundColorTransition, borderTransition, colorTransition, darkBlue, darkPurple, white, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Skin.Global exposing (darkBlue, darkPurple, white)
+import Theme.GlobalLayout exposing (backgroundColorTransition, borderTransition, colorTransition, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
 type Msg

--- a/src/Theme/TextHeavyPage.elm
+++ b/src/Theme/TextHeavyPage.elm
@@ -4,7 +4,7 @@ import Css exposing (Style, auto, batch, margin2, marginBottom, marginTop, maxWi
 import Html.Styled exposing (Html, section)
 import Html.Styled.Attributes exposing (css)
 import Markdown.Block
-import Theme.Global exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.GlobalLayout exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate as PageTemplate
 import Theme.TransMarkdown
 

--- a/src/Theme/TransMarkdown.elm
+++ b/src/Theme/TransMarkdown.elm
@@ -8,7 +8,8 @@ import Markdown.Block
 import Markdown.Html
 import Markdown.Parser
 import Markdown.Renderer
-import Theme.Global exposing (linkStyle, pink, withMediaSmallDesktopUp, withMediaTabletLandscapeUp)
+import Skin.Global exposing (linkStyle, pink)
+import Theme.GlobalLayout exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp)
 
 
 fromResult : Result String value -> Json.Decode.Decoder value

--- a/theme/Skin/Global.elm
+++ b/theme/Skin/Global.elm
@@ -1,13 +1,13 @@
-module Theme.Global exposing (backgroundColorTransition, borderTransition, buttonFloatingWrapperStyle, colorTransition, containerPage, contentContainerStyle, contentWrapperStyle, darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, darkBlueRgbColor, darkPurple, globalStyles, hrStyle, introTextLargeStyle, introTextSmallStyle, linkStyle, mapImage, mapImageMulti, maxMobile, maxTabletPortrait, normalFirstParagraphStyle, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, pinkButtonOnLightBackgroundStyle, pinkRgbColor, purple, screenReaderOnly, smallFloatingTitleStyle, smallInlineTitleStyle, textBoxInvisibleStyle, textBoxPinkStyle, textInputErrorStyle, textInputStyle, viewBackButton, viewCheckbox, white, whiteButtonStyle, withMediaCanHover, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+module Skin.Global exposing (contentWrapperStyle, darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, darkBlueRgbColor, darkPurple, globalStyles, hrStyle, introTextLargeStyle, introTextSmallStyle, linkStyle, mapImage, mapImageMulti, normalFirstParagraphStyle, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, pinkButtonOnLightBackgroundStyle, pinkRgbColor, purple, smallFloatingTitleStyle, smallInlineTitleStyle, textBoxInvisibleStyle, textBoxPinkStyle, textInputErrorStyle, textInputStyle, viewBackButton, viewCheckbox, white, whiteButtonStyle)
 
 import Color
 import Css exposing (Color, Style, absolute, active, alignItems, auto, backgroundColor, backgroundImage, backgroundRepeat, backgroundSize, batch, block, borderBottomColor, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderRadius, borderStyle, borderWidth, bottom, boxSizing, calc, center, color, cursor, display, displayFlex, em, firstChild, fitContent, flexDirection, focus, fontFamilies, fontSize, fontStyle, fontWeight, height, hex, hidden, hover, inlineBlock, int, italic, justifyContent, left, letterSpacing, lineHeight, margin, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxContent, maxWidth, minus, none, outline, overflow, padding, padding2, padding4, paddingBottom, paddingLeft, paddingRight, pct, pointer, position, property, px, relative, rem, repeat, row, sansSerif, solid, textAlign, textDecoration, textTransform, top, uppercase, url, width, zero)
 import Css.Global exposing (adjacentSiblings, descendants, global, typeSelector)
-import Css.Media as Media exposing (fine, only, screen, withMedia)
 import Css.Transitions exposing (Transition, linear, transition)
 import Html.Styled exposing (Html, a, div, img, input, label, p, text)
 import Html.Styled.Attributes exposing (alt, css, for, href, id, src, type_)
 import Html.Styled.Events exposing (onCheck)
+import Theme.GlobalLayout exposing (withMediaCanHover, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp)
 
 
 
@@ -55,110 +55,19 @@ white =
 
 
 
--- Accent colours
--- Text and background colours
--- Breakpoints
-
-
-maxMobile : Float
-maxMobile =
-    600
-
-
-withMediaMobileOnly : List Style -> Style
-withMediaMobileOnly =
-    withMedia [ only screen [ Media.maxWidth (px (maxMobile - 1)) ] ]
-
-
-withMediaTabletPortraitUp : List Style -> Style
-withMediaTabletPortraitUp =
-    withMedia [ only screen [ Media.minWidth (px maxMobile) ] ]
-
-
-maxTabletPortrait : Float
-maxTabletPortrait =
-    900
-
-
-withMediaTabletLandscapeUp : List Style -> Style
-withMediaTabletLandscapeUp =
-    withMedia [ only screen [ Media.minWidth (px maxTabletPortrait) ] ]
-
-
-maxTabletLandscape : Float
-maxTabletLandscape =
-    1200
-
-
-withMediaSmallDesktopUp : List Style -> Style
-withMediaSmallDesktopUp =
-    withMedia [ only screen [ Media.minWidth (px maxTabletLandscape) ] ]
-
-
-maxSmallDesktop : Float
-maxSmallDesktop =
-    1500
-
-
-withMediaMediumDesktopUp : List Style -> Style
-withMediaMediumDesktopUp =
-    withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
-
-
-withMediaCanHover : List Style -> Style
-withMediaCanHover =
-    withMedia [ only screen [ Media.hover Media.canHover, Media.pointer fine ] ]
-
-
-
--- Transitions
-
-
-borderTransition : Transition
-borderTransition =
-    Css.Transitions.border3 500 0 linear
-
-
-colorTransition : Transition
-colorTransition =
-    Css.Transitions.color3 500 0 linear
-
-
-backgroundColorTransition : Transition
-backgroundColorTransition =
-    Css.Transitions.backgroundColor3 500 0 linear
-
-
-
--- Buttons (components)
+-- Buttons
 
 
 viewBackButton : String -> String -> Html msg
 viewBackButton link buttonText =
-    p [ css [ backButtonStyle ] ]
+    p [ css [ Theme.GlobalLayout.backButtonStyle ] ]
         [ a [ href link, css [ darkBlueButtonStyle ] ] [ text buttonText ] ]
-
-
-
--- Buttons (styles)
-
-
-buttonFloatingWrapperStyle : Style
-buttonFloatingWrapperStyle =
-    batch
-        [ margin2 (rem 1) auto
-        , display block
-        , position absolute
-        , bottom (rem -2)
-        , textAlign center
-        , width (pct 100)
-        ]
 
 
 whiteButtonStyle : Style
 whiteButtonStyle =
     batch
-        [ baseButtonStyle
+        [ Theme.GlobalLayout.baseButtonStyle
         , backgroundColor white
         , color darkBlue
         , borderColor white
@@ -171,11 +80,11 @@ whiteButtonStyle =
 darkBlueButtonStyle : Style
 darkBlueButtonStyle =
     batch
-        [ baseButtonStyle
+        [ Theme.GlobalLayout.baseButtonStyle
         , backgroundColor darkBlue
         , color white
         , borderColor pink
-        , withMediaCanHover [ hover [ backgroundColor purple, color white, borderColor white ] ]
+        , Theme.GlobalLayout.withMediaCanHover [ hover [ backgroundColor purple, color white, borderColor white ] ]
         , active [ backgroundColor pink, color darkBlue, borderColor white ]
         , focus [ backgroundColor pink, color darkBlue, borderColor white ]
         ]
@@ -184,7 +93,7 @@ darkBlueButtonStyle =
 pinkButtonOnDarkBackgroundStyle : Style
 pinkButtonOnDarkBackgroundStyle =
     batch
-        [ baseButtonStyle
+        [ Theme.GlobalLayout.baseButtonStyle
         , backgroundColor pink
         , color darkBlue
         , borderColor pink
@@ -197,39 +106,13 @@ pinkButtonOnDarkBackgroundStyle =
 pinkButtonOnLightBackgroundStyle : Style
 pinkButtonOnLightBackgroundStyle =
     batch
-        [ baseButtonStyle
+        [ Theme.GlobalLayout.baseButtonStyle
         , backgroundColor pink
         , color darkBlue
         , borderColor pink
         , withMediaCanHover [ hover [ backgroundColor purple, borderColor white, color white ] ]
         , active [ backgroundColor darkBlue, borderColor white, color white ]
         , focus [ backgroundColor darkBlue, borderColor white, color white ]
-        ]
-
-
-baseButtonStyle : Style
-baseButtonStyle =
-    batch
-        [ textDecoration none
-        , padding4 (rem 0.375) (rem 1.25) (rem 0.5) (rem 1.25)
-        , borderRadius (rem 0.3)
-        , fontWeight (int 600)
-        , fontSize (rem 1.2)
-        , display block
-        , textAlign center
-        , maxWidth maxContent
-        , margin2 (rem 0) auto
-        , borderWidth (rem 0.2)
-        , borderStyle solid
-        , transition [ backgroundColorTransition, borderTransition, colorTransition ]
-        ]
-
-
-backButtonStyle : Style
-backButtonStyle =
-    batch
-        [ textAlign center
-        , margin4 (rem 3) (rem 2) (rem 0) (rem 2)
         ]
 
 
@@ -289,6 +172,17 @@ smallInlineTitleStyle =
 -- Page Elements
 
 
+contentWrapperStyle : Style
+contentWrapperStyle =
+    batch
+        [ borderRadius (rem 0.3)
+        , backgroundColor darkBlue
+        , borderColor pink
+        , borderStyle solid
+        , borderWidth (px 1)
+        ]
+
+
 textBoxStyle : Style
 textBoxStyle =
     batch
@@ -297,7 +191,7 @@ textBoxStyle =
         , padding2 (rem 1) (rem 0.75)
         , withMediaMediumDesktopUp
             [ paddingBottom (rem 2) ]
-        , withMediaTabletPortraitUp
+        , Theme.GlobalLayout.withMediaTabletPortraitUp
             [ paddingLeft (rem 1.5), paddingRight (rem 1.5) ]
         ]
 
@@ -319,29 +213,9 @@ textBoxInvisibleStyle =
         , textBoxStyle
         , paddingBottom (rem 0)
         , descendants
-            [ typeSelector "h3" [ batch [ color pink, withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
-            , typeSelector "p" [ batch [ color pink, withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
+            [ typeSelector "h3" [ batch [ color pink, Theme.GlobalLayout.withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
+            , typeSelector "p" [ batch [ color pink, Theme.GlobalLayout.withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
             ]
-        ]
-
-
-contentWrapperStyle : Style
-contentWrapperStyle =
-    batch
-        [ borderRadius (rem 0.3)
-        , backgroundColor darkBlue
-        , borderColor pink
-        , borderStyle solid
-        , borderWidth (px 1)
-        ]
-
-
-contentContainerStyle : Style
-contentContainerStyle =
-    batch
-        [ margin (rem 0.75)
-        , withMediaMediumDesktopUp [ margin (rem 1.5) ]
-        , withMediaTabletPortraitUp [ margin2 (rem 0) (rem 2) ]
         ]
 
 
@@ -368,9 +242,9 @@ introTextLargeStyle =
         , fontStyle italic
         , fontWeight (int 500)
         , margin2 (rem 1) (rem 0.5)
-        , withMediaTabletLandscapeUp
+        , Theme.GlobalLayout.withMediaTabletLandscapeUp
             [ fontSize (rem 2.5), lineHeight (rem 3.1), maxWidth (px 838), margin2 (rem 3) auto ]
-        , withMediaTabletPortraitUp
+        , Theme.GlobalLayout.withMediaTabletPortraitUp
             [ fontSize (rem 1.9), lineHeight (rem 2.1), margin2 (rem 1) (rem 1.5) ]
         ]
 
@@ -380,9 +254,9 @@ introTextSmallStyle =
     batch
         [ textAlign center
         , margin2 (rem 1.5) (rem 0)
-        , withMediaTabletLandscapeUp
+        , Theme.GlobalLayout.withMediaTabletLandscapeUp
             [ fontSize (rem 1.2), margin2 (rem 1.5) (rem 6.5) ]
-        , withMediaTabletPortraitUp
+        , Theme.GlobalLayout.withMediaTabletPortraitUp
             [ margin2 (rem 1.5) (rem 3.5) ]
         ]
 
@@ -396,19 +270,7 @@ linkStyle =
         , borderBottomWidth (px 1)
         , textDecoration none
         , withMediaCanHover [ hover [ color pink, borderBottomColor white ] ]
-        , transition [ borderTransition, colorTransition ]
-        ]
-
-
-screenReaderOnly : Style
-screenReaderOnly =
-    batch
-        [ position absolute
-        , left (px -10000)
-        , top auto
-        , width (px 1)
-        , height (px 1)
-        , overflow hidden
+        , transition [ Theme.GlobalLayout.borderTransition, Theme.GlobalLayout.colorTransition ]
         ]
 
 
@@ -426,8 +288,8 @@ normalFirstParagraphStyle =
                         [ fontSize (rem 1)
                         , marginBlockEnd (em 1)
                         , lineHeight (em 1.5)
-                        , withMediaSmallDesktopUp [ fontSize (rem 1.2) ]
-                        , withMediaTabletPortraitUp [ marginBlockStart (em 0) ]
+                        , Theme.GlobalLayout.withMediaSmallDesktopUp [ fontSize (rem 1.2) ]
+                        , Theme.GlobalLayout.withMediaTabletPortraitUp [ marginBlockStart (em 0) ]
                         ]
                     ]
                 ]
@@ -499,7 +361,7 @@ checkboxLabelStyle =
         , position relative
         , cursor pointer
         , maxWidth fitContent
-        , withMediaTabletPortraitUp [ maxWidth (pct 100) ]
+        , Theme.GlobalLayout.withMediaTabletPortraitUp [ maxWidth (pct 100) ]
         , focus [ color white ]
         ]
 
@@ -552,8 +414,8 @@ globalStyles =
             , backgroundImage (url "/images/backgrounds/starfield-small-800.png")
             , backgroundRepeat repeat
             , backgroundSize (px 800)
-            , withMediaMediumDesktopUp [ backgroundImage (url "/images/backgrounds/starfield-largest-1920.png"), backgroundSize (px 1920) ]
-            , withMediaTabletLandscapeUp [ backgroundImage (url "/images/backgrounds/starfield-medium-1080.png"), backgroundSize (px 1080) ]
+            , Theme.GlobalLayout.withMediaMediumDesktopUp [ backgroundImage (url "/images/backgrounds/starfield-largest-1920.png"), backgroundSize (px 1920) ]
+            , Theme.GlobalLayout.withMediaTabletLandscapeUp [ backgroundImage (url "/images/backgrounds/starfield-medium-1080.png"), backgroundSize (px 1080) ]
             ]
         , typeSelector "h1"
             [ color darkBlue
@@ -681,6 +543,6 @@ mapStyle =
         [ height (px 318)
         , width (pct 100)
         , property "object-fit" "cover"
-        , withMediaTabletLandscapeUp [ height (px 400) ]
+        , Theme.GlobalLayout.withMediaTabletLandscapeUp [ height (px 400) ]
         , borderRadius (rem 0.3)
         ]


### PR DESCRIPTION
Fixes #4

## Description

- Create `Skin.Global` and `GlobalLayout` to start seperation of core styles from template customisations
- Improve readme around how to populate a template site
