### PR TITLE
Fix/6 rename trans dim specific keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Front-end for a PlaceCal instance, an online community hub.
 - [ ] Edit `theme/Copy/Text` to generate your UI & SEO text
 - [ ] Add your images, like logos and background to `public/images`
 - [ ] Edit the reset and core css styles like fonts in `public/css`
+- [ ] Add your brand colors to `theme/Global/Skin` following guidence there
 
 
 # Development

--- a/app/Route/Events.elm
+++ b/app/Route/Events.elm
@@ -196,7 +196,7 @@ view app _ model =
     { title = t (PageMetaTitle (t EventsTitle))
     , body =
         [ Theme.PageTemplate.view
-            { headerType = Just "pink"
+            { headerType = Just "secondary"
             , title = t EventsTitle
             , bigText = { text = t EventsSummary, node = "h3" }
             , smallText = Nothing

--- a/app/Route/Events/Event_.elm
+++ b/app/Route/Events/Event_.elm
@@ -111,7 +111,7 @@ view app _ =
     { title = t (PageMetaTitle event.name)
     , body =
         [ Theme.PageTemplate.view
-            { headerType = Just "pink"
+            { headerType = Just "secondary"
             , title = t EventsTitle
             , bigText = { text = event.name, node = "h3" }
             , smallText = Nothing

--- a/app/Route/JoinUs.elm
+++ b/app/Route/JoinUs.elm
@@ -94,7 +94,7 @@ view _ _ model =
     { title = t (PageMetaTitle (t JoinUsTitle))
     , body =
         [ Theme.PageTemplate.view
-            { headerType = Just "pink"
+            { headerType = Just "secondary"
             , title = t JoinUsTitle
             , bigText = { text = t JoinUsSubtitle, node = "p" }
             , smallText = Just [ t JoinUsDescription ]

--- a/app/Route/News.elm
+++ b/app/Route/News.elm
@@ -70,7 +70,7 @@ view app _ =
     { title = t (PageMetaTitle (t NewsTitle))
     , body =
         [ Theme.PageTemplate.view
-            { headerType = Just "pink"
+            { headerType = Just "secondary"
             , title = t NewsTitle
             , bigText = { text = t NewsDescription, node = "h3" }
             , smallText = Nothing

--- a/app/Route/Partners.elm
+++ b/app/Route/Partners.elm
@@ -13,6 +13,7 @@ import Effect
 import FatalError
 import Head
 import Html.Styled
+import Messages exposing (Msg(..))
 import PagesMsg
 import RouteBuilder
 import Shared
@@ -21,7 +22,6 @@ import Theme.PageTemplate
 import Theme.RegionSelector exposing (Msg(..))
 import UrlPath
 import View
-import Messages exposing (Msg(..))
 
 
 type alias Model =
@@ -111,7 +111,7 @@ view app _ model =
     { title = t (PageMetaTitle (t PartnersTitle))
     , body =
         [ Theme.PageTemplate.view
-            { headerType = Just "pink"
+            { headerType = Just "secondary"
             , title = t PartnersTitle
             , bigText = { text = t PartnersIntroSummary, node = "p" }
             , smallText = Just [ t PartnersIntroDescription ]

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -223,7 +223,7 @@ view app _ model =
     { title = t (PageMetaTitle aPartner.name)
     , body =
         [ Theme.PageTemplate.view
-            { headerType = Just "pink"
+            { headerType = Just "secondary"
             , title = t PartnersTitle
             , bigText = { text = aPartner.name, node = "h3" }
             , smallText = Nothing

--- a/app/Site.elm
+++ b/app/Site.elm
@@ -24,8 +24,8 @@ head : BackendTask FatalError (List Head.Tag)
 head =
     [ Head.sitemapLink "/sitemap.xml"
     , Head.appleTouchIcon (Just 180) (pathFromString "/favicons/apple-touch-icon.png")
-    , Head.metaName "msapplication-TileColor" (Head.raw "#ff7aa7")
-    , Head.metaName "theme-color" (Head.raw "#FF7AA7")
+    , Head.metaName "msapplication-TileColor" (Head.raw Skin.Global.colorSecondaryHexString)
+    , Head.metaName "theme-color" (Head.raw Skin.Global.colorSecondaryHexString)
     ]
         ++ icons
             [ ( 32, "favicon-32x32.png" )
@@ -53,8 +53,8 @@ manifest =
               }
             ]
         }
-        |> Manifest.withBackgroundColor Skin.Global.darkBlueRgbColor
-        |> Manifest.withThemeColor Skin.Global.pinkRgbColor
+        |> Manifest.withBackgroundColor Skin.Global.colorPrimaryRgb
+        |> Manifest.withThemeColor Skin.Global.colorSecondaryRgb
 
 
 pathFromString srcString =

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -9,12 +9,12 @@ type Prefix
 type Key
     = SiteTitle
     | SiteStrapline
-    | TransDimensionDescription
+    | CommunityDescription
     | SiteLogoSrc
     | PageMetaTitle String
     | GeeksForSocialChangeHomeUrl
-    | GenderedIntelligenceHomeUrl
-    | GenderedIntelligenceLogoTxt
+    | PartnerOrganisationHomeUrl
+    | PartnerOrganisationLogoTxt
     | GoogleMapSearchUrl String
     | SeeOnGoogleMapText
     | MapImageAltText String

--- a/src/Copy/Utils.elm
+++ b/src/Copy/Utils.elm
@@ -1,0 +1,37 @@
+module Copy.Utils exposing (isValidUrl, urlToDisplay)
+
+import Url
+
+
+urlRecombiner : Maybe Url.Url -> String
+urlRecombiner urlRecord =
+    case urlRecord of
+        Just url ->
+            url.host ++ url.path ++ Maybe.withDefault "" url.query ++ Maybe.withDefault "" url.fragment
+
+        Nothing ->
+            ""
+
+
+chompTrailingUrlSlash : String -> String
+chompTrailingUrlSlash urlString =
+    if String.endsWith "/" urlString then
+        String.dropRight 1 urlString
+
+    else
+        urlString
+
+
+urlToDisplay : String -> String
+urlToDisplay url =
+    Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
+
+
+isValidUrl : String -> Bool
+isValidUrl urlString =
+    case Url.fromString urlString of
+        Just url ->
+            url.protocol == Url.Https
+
+        Nothing ->
+            False

--- a/src/Data/PlaceCal/Articles.elm
+++ b/src/Data/PlaceCal/Articles.elm
@@ -3,7 +3,7 @@ module Data.PlaceCal.Articles exposing (Article, articleFromSlug, articlesData, 
 import Array
 import BackendTask
 import BackendTask.Custom
-import Copy.Text exposing (isValidUrl)
+import Copy.Utils exposing (isValidUrl)
 import Data.PlaceCal.Api
 import Data.PlaceCal.Partners
 import FatalError

--- a/src/Theme/Page/About.elm
+++ b/src/Theme/Page/About.elm
@@ -5,7 +5,7 @@ import Css.Global exposing (descendants, typeSelector)
 import Html.Styled exposing (Html, a, div, h3, h4, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import Markdown.Block
-import Skin.Global exposing (contentWrapperStyle, introTextLargeStyle, normalFirstParagraphStyle, smallFloatingTitleStyle, textBoxPinkStyle, whiteButtonStyle)
+import Skin.Global exposing (contentWrapperStyle, introTextLargeStyle, normalFirstParagraphStyle, smallFloatingTitleStyle, textBoxSecondaryStyle, whiteButtonStyle)
 import Theme.GlobalLayout exposing (buttonFloatingWrapperStyle, contentContainerStyle, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate
 import Theme.TransMarkdown
@@ -34,7 +34,7 @@ viewAccessibility : Theme.PageTemplate.SectionWithTextHeader -> Html msg
 viewAccessibility { title, subtitle, body } =
     section [ css [ contentWrapperStyle, accessibilityStyle ] ]
         [ h3 [ css [ smallFloatingTitleStyle, withMediaMobileOnly [ top (rem -4.5) ] ] ] [ text title ]
-        , div [ css [ textBoxPinkStyle, accessibilityCharactersStyle ] ] [ p [ css [ introTextLargeStyle ] ] [ text subtitle ] ]
+        , div [ css [ textBoxSecondaryStyle, accessibilityCharactersStyle ] ] [ p [ css [ introTextLargeStyle ] ] [ text subtitle ] ]
         , div [ css [ contentContainerStyle, aboutAccessibilityTextStyle ] ] (Theme.TransMarkdown.markdownBlocksToHtml body)
         ]
 
@@ -51,7 +51,7 @@ viewMakers makersList =
 
 viewMaker : { name : String, url : String, logo : String, body : List Markdown.Block.Block } -> Html msg
 viewMaker { name, url, logo, body } =
-    div [ css [ makerStyle, textBoxPinkStyle ] ]
+    div [ css [ makerStyle, textBoxSecondaryStyle ] ]
         [ h4 [ css [ makerHeaderStyle ] ] [ img [ src logo, alt name, css [ makerLogoStyle ] ] [] ]
         , div [ css [ normalFirstParagraphStyle ] ] (Theme.TransMarkdown.markdownBlocksToHtml body)
         , p [ css [ buttonFloatingWrapperStyle ] ] [ a [ href url, css [ whiteButtonStyle ] ] [ text "Find out more" ] ]
@@ -62,7 +62,7 @@ viewAboutPlaceCal : Theme.PageTemplate.SectionWithImageHeader -> Html msg
 viewAboutPlaceCal { title, subtitleimg, subtitleimgalt, body } =
     section [ css [ contentWrapperStyle, placeCalStyle ] ]
         [ h3 [ css [ smallFloatingTitleStyle ] ] [ text title ]
-        , div [ css [ textBoxPinkStyle ] ]
+        , div [ css [ textBoxSecondaryStyle ] ]
             [ img
                 [ src subtitleimg
                 , alt subtitleimgalt

--- a/src/Theme/Page/Event.elm
+++ b/src/Theme/Page/Event.elm
@@ -9,7 +9,7 @@ import Helpers.TransDate
 import Helpers.TransRoutes
 import Html.Styled exposing (Html, a, div, h4, hr, p, section, text, time)
 import Html.Styled.Attributes exposing (css, href, target)
-import Skin.Global exposing (hrStyle, linkStyle, mapImage, normalFirstParagraphStyle, pink, smallInlineTitleStyle, viewBackButton)
+import Skin.Global exposing (colorSecondary, hrStyle, linkStyle, mapImage, normalFirstParagraphStyle, smallInlineTitleStyle, viewBackButton)
 import Theme.GlobalLayout exposing (withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.TransMarkdown
 
@@ -182,7 +182,7 @@ timeStyle =
         , textAlign center
         , textTransform uppercase
         , letterSpacing (px 1.9)
-        , color pink
+        , color colorSecondary
         , marginBlockStart (em 0)
         ]
 
@@ -235,7 +235,7 @@ addressItemStyle =
 addressItemTitleStyle : Style
 addressItemTitleStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , smallInlineTitleStyle
         , withMediaTabletPortraitUp [ marginTop (rem 1) ]
         ]

--- a/src/Theme/Page/Event.elm
+++ b/src/Theme/Page/Event.elm
@@ -1,7 +1,8 @@
 module Theme.Page.Event exposing (viewButtons, viewEventInfo)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (isValidUrl, t)
+import Copy.Text exposing (t)
+import Copy.Utils exposing (isValidUrl, urlToDisplay)
 import Css exposing (Style, auto, batch, calc, center, color, displayFlex, em, fontSize, fontStyle, fontWeight, int, justifyContent, letterSpacing, margin2, margin4, marginBlockEnd, marginBlockStart, marginBottom, marginTop, maxWidth, minus, normal, pct, px, rem, textAlign, textTransform, uppercase, width)
 import Data.PlaceCal.Events
 import Helpers.TransDate
@@ -88,7 +89,7 @@ viewAddressSection event =
                     if isValidUrl url then
                         p [ css [ contactItemStyle ] ]
                             [ a [ href url, target "_blank", css [ linkStyle ] ]
-                                [ text (Copy.Text.urlToDisplay url) ]
+                                [ text (urlToDisplay url) ]
                             ]
 
                     else

--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -12,7 +12,7 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, button, div, h4, li, p, section, span, text, time, ul)
 import Html.Styled.Attributes exposing (css, href)
 import Html.Styled.Events
-import Skin.Global exposing (darkBlue, introTextLargeStyle, pink, white)
+import Skin.Global exposing (colorPrimary, colorSecondary, colorWhite, introTextLargeStyle)
 import Theme.GlobalLayout exposing (borderTransition, colorTransition, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Paginator exposing (buttonWidthFullWidth, buttonWidthMobile, buttonWidthTablet, paginationButtonStyle)
 import Theme.RegionSelector
@@ -113,7 +113,7 @@ viewEventsList localModel eventsList maybeListLength =
 
 viewEmptyEventText : Theme.Paginator.Filter -> Html Msg
 viewEmptyEventText filterBy =
-    p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ]
+    p [ css [ introTextLargeStyle, color colorSecondary, important (maxWidth (px 636)) ] ]
         [ text
             (case filterBy of
                 Theme.Paginator.Day _ ->
@@ -196,11 +196,11 @@ eventsListItemStyle =
         [ withMediaCanHover
             [ hover
                 [ descendants
-                    [ typeSelector "a" [ color pink ]
-                    , typeSelector "h4" [ color pink, borderBottomColor white ]
+                    [ typeSelector "a" [ color colorSecondary ]
+                    , typeSelector "h4" [ color colorSecondary, borderBottomColor colorWhite ]
                     , typeSelector "span"
-                        [ firstChild [ color pink ]
-                        , lastChild [ color white ]
+                        [ firstChild [ color colorSecondary ]
+                        , lastChild [ color colorWhite ]
                         ]
                     ]
                 ]
@@ -233,7 +233,7 @@ eventDateStyle =
 eventDayStyle : Style
 eventDayStyle =
     batch
-        [ color white
+        [ color colorWhite
         , fontSize (rem 2.5)
         , display block
         , lineHeight (em 1)
@@ -245,7 +245,7 @@ eventDayStyle =
 eventMonthStyle : Style
 eventMonthStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , textTransform uppercase
         , fontSize (rem 1.2)
         , fontWeight (int 900)
@@ -263,7 +263,7 @@ eventDescriptionStyle =
 eventTitleStyle : Style
 eventTitleStyle =
     batch
-        [ color white
+        [ color colorWhite
         , fontStyle italic
         , fontSize (rem 1.2)
         , fontWeight (int 500)
@@ -271,7 +271,7 @@ eventTitleStyle =
         , paddingBottom (rem 0.5)
         , marginBottom (rem 0.5)
         , borderBottomWidth (px 2)
-        , borderBottomColor pink
+        , borderBottomColor colorSecondary
         , borderBottomStyle solid
         , transition [ colorTransition, borderTransition ]
         , withMediaTabletPortraitUp [ fontSize (rem 1.5), lineHeight (rem 1.877) ]
@@ -282,7 +282,7 @@ eventLinkStyle : Style
 eventLinkStyle =
     batch
         [ textDecoration none
-        , color white
+        , color colorWhite
         , transition [ colorTransition ]
         ]
 
@@ -314,7 +314,7 @@ goToNextEventButtonStyle =
         , fontWeight (int 600)
         , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
         , width (px buttonWidthMobile)
-        , backgroundColor darkBlue
+        , backgroundColor colorPrimary
         , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
         , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
         ]

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -9,7 +9,7 @@ import Data.PlaceCal.Partners
 import Helpers.TransRoutes
 import Html.Styled exposing (Html, a, div, h1, h2, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src)
-import Skin.Global exposing (darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, smallFloatingTitleStyle, whiteButtonStyle)
+import Skin.Global exposing (colorPrimary, colorSecondary, primaryBackgroundStyle, primaryButtonStyle, secondaryBackgroundStyle, secondaryButtonOnDarkBackgroundStyle, smallFloatingTitleStyle, whiteButtonStyle)
 import Theme.GlobalLayout
     exposing
         ( buttonFloatingWrapperStyle
@@ -47,7 +47,7 @@ view sharedData localModel =
 
 viewIntro : String -> String -> String -> Html msg
 viewIntro introTitle introMsg eventButtonText =
-    section [ css [ sectionStyle, pinkBackgroundStyle, introSectionStyle ] ]
+    section [ css [ sectionStyle, secondaryBackgroundStyle, introSectionStyle ] ]
         [ h1 [ css [ logoStyle ] ]
             [ img
                 [ src "/images/logos/tdd_logo_with_strapline.svg"
@@ -70,7 +70,7 @@ viewIntro introTitle introMsg eventButtonText =
 
 viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
 viewFeatured fromTime eventList regionId =
-    section [ css [ sectionStyle, darkBlueBackgroundStyle, eventsSectionStyle ] ]
+    section [ css [ sectionStyle, primaryBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
         , if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
             Theme.RegionSelector.viewRegionSelector { filterBy = regionId } |> Html.Styled.map fromRegionSelectorMsg
@@ -87,7 +87,7 @@ viewAllEventsButton =
     p [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
         [ a
             [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.Events)
-            , css [ pinkButtonOnDarkBackgroundStyle ]
+            , css [ secondaryButtonOnDarkBackgroundStyle ]
             ]
             [ text (t IndexFeaturedButtonText) ]
         ]
@@ -95,7 +95,7 @@ viewAllEventsButton =
 
 viewLatestNews : Maybe Data.PlaceCal.Articles.Article -> String -> String -> Html msg
 viewLatestNews maybeNewsItem title buttonText =
-    section [ css [ sectionStyle, darkBlueBackgroundStyle, newsSectionStyle ] ]
+    section [ css [ sectionStyle, primaryBackgroundStyle, newsSectionStyle ] ]
         [ h2 [ css [ smallFloatingTitleStyle ] ] [ text title ]
         , case maybeNewsItem of
             Just news ->
@@ -106,7 +106,7 @@ viewLatestNews maybeNewsItem title buttonText =
         , p [ css [ buttonFloatingWrapperStyle, bottom (rem -6), width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (Helpers.TransRoutes.toAbsoluteUrl Helpers.TransRoutes.News)
-                , css [ darkBlueButtonStyle ]
+                , css [ primaryButtonStyle ]
                 ]
                 [ text buttonText ]
             ]
@@ -210,7 +210,7 @@ sectionSubtitleStyle =
         , fontSize (rem 2.1)
         , lineHeight (em 1.1)
         , fontWeight (int 500)
-        , color darkBlue
+        , color colorPrimary
         , withMediaSmallDesktopUp
             [ margin2 (rem 0.5) (rem 1) ]
         , withMediaTabletPortraitUp
@@ -226,7 +226,7 @@ sectionTextStyle : Style
 sectionTextStyle =
     batch
         [ textAlign center
-        , color darkBlue
+        , color colorPrimary
         , withMediaSmallDesktopUp
             [ margin2 (rem 2) (rem 8) ]
         , withMediaTabletPortraitUp

--- a/src/Theme/Page/JoinUs.elm
+++ b/src/Theme/Page/JoinUs.elm
@@ -12,7 +12,7 @@ import Http
 import Json.Encode
 import RouteBuilder
 import Shared
-import Skin.Global exposing (pink, pinkButtonOnDarkBackgroundStyle, textInputErrorStyle, textInputStyle, viewCheckbox, white)
+import Skin.Global exposing (colorSecondary, colorWhite, secondaryButtonOnDarkBackgroundStyle, textInputErrorStyle, textInputStyle, viewCheckbox)
 import Task
 import Theme.GlobalLayout exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
@@ -524,7 +524,7 @@ textAreaStyle =
         , height (px 140)
         , margin2 (rem 0.5) (rem 0)
         , padding2 (rem 1) (rem 1.5)
-        , pseudoElement "placeholder" [ color white ]
+        , pseudoElement "placeholder" [ color colorWhite ]
         , width (pct 100)
         , withMediaTabletPortraitUp [ height (px 100) ]
         ]
@@ -554,7 +554,7 @@ buttonWrapperStyle =
 formHelperStyle : Style
 formHelperStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , fontSize (rem 0.875)
         , fontWeight (int 600)
         , textAlign center
@@ -568,7 +568,7 @@ formHelperStyle =
 formButtonStyle : Style
 formButtonStyle =
     batch
-        [ pinkButtonOnDarkBackgroundStyle
+        [ secondaryButtonOnDarkBackgroundStyle
         , padding2 (rem 0.25) (rem 4)
         , withMediaTabletPortraitUp [ marginTop (rem 1) ]
         ]

--- a/src/Theme/Page/News.elm
+++ b/src/Theme/Page/News.elm
@@ -8,7 +8,7 @@ import Helpers.TransDate as TransDate
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, div, h3, img, li, p, section, span, text, time, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
-import Skin.Global exposing (darkBlueBackgroundStyle, linkStyle, pinkButtonOnLightBackgroundStyle)
+import Skin.Global exposing (linkStyle, primaryBackgroundStyle, secondaryButtonOnLightBackgroundStyle)
 import Theme.GlobalLayout exposing (buttonFloatingWrapperStyle, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
@@ -57,7 +57,7 @@ viewNewsArticle newsItem =
             ]
         , div [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
-                [ css [ pinkButtonOnLightBackgroundStyle ]
+                [ css [ secondaryButtonOnLightBackgroundStyle ]
                 , href
                     (TransRoutes.toAbsoluteUrl
                         (NewsItem (TransRoutes.stringToSlug newsItem.title))
@@ -87,7 +87,7 @@ newsArticleImage imageSrc =
 newsItemStyle : Style
 newsItemStyle =
     batch
-        [ darkBlueBackgroundStyle
+        [ primaryBackgroundStyle
         , margin4 (rem 2) (rem 0) (rem 3) (rem 0)
         , borderRadius (rem 0.2)
         , padding4 (rem 1.25) (rem 1.25) (rem 3) (rem 1.25)

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -8,7 +8,7 @@ import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, a, address, div, h3, hr, p, section, span, text)
 import Html.Styled.Attributes exposing (css, href, id, target)
-import Skin.Global exposing (hrStyle, introTextLargeStyle, linkStyle, mapImage, normalFirstParagraphStyle, pink, smallInlineTitleStyle, white)
+import Skin.Global exposing (colorSecondary, colorWhite, hrStyle, introTextLargeStyle, linkStyle, mapImage, normalFirstParagraphStyle, smallInlineTitleStyle)
 import Theme.GlobalLayout
     exposing
         ( withMediaMediumDesktopUp
@@ -78,7 +78,7 @@ viewPartnerEvents :
 viewPartnerEvents events localModel partner =
     let
         eventAreaTitle =
-            h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
+            h3 [ css [ smallInlineTitleStyle, color colorWhite ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
 
         futureEvents =
             Data.PlaceCal.Events.afterDate events localModel.nowTime
@@ -107,7 +107,7 @@ viewPartnerEvents events localModel partner =
             if List.length pastEvents > 0 then
                 -- If there are no future events but there were in the past, show them
                 [ div []
-                    [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerPreviousEventsText partner.name)) ]
+                    [ h3 [ css [ smallInlineTitleStyle, color colorWhite ] ] [ text (t (PartnerPreviousEventsText partner.name)) ]
                     , Theme.Page.Events.viewEventsList { localModel | filterByDate = Theme.Paginator.None } pastEvents Nothing
                     ]
                 ]
@@ -115,7 +115,7 @@ viewPartnerEvents events localModel partner =
             else
                 -- This partner has never had events
                 [ eventAreaTitle
-                , p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
+                , p [ css [ introTextLargeStyle, color colorSecondary, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
                 ]
         )
 
@@ -239,7 +239,7 @@ contactSectionStyle =
 
 contactHeadingStyle : Style
 contactHeadingStyle =
-    batch [ color pink ]
+    batch [ color colorSecondary ]
 
 
 contactItemStyle : Style

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -2,6 +2,7 @@ module Theme.Page.Partner exposing (viewInfo)
 
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
+import Copy.Utils exposing (urlToDisplay)
 import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -153,13 +154,13 @@ viewContactDetails maybeUrl maybeContactDetails maybeInstagramUrl =
                     text ""
             , case maybeUrl of
                 Just url ->
-                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (urlToDisplay url) ] ]
 
                 Nothing ->
                     text ""
             , case maybeInstagramUrl of
                 Just url ->
-                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (urlToDisplay url) ] ]
 
                 Nothing ->
                     text ""

--- a/src/Theme/Page/Partners.elm
+++ b/src/Theme/Page/Partners.elm
@@ -9,7 +9,7 @@ import Data.PlaceCal.Partners
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, div, h3, h4, li, p, section, span, styled, text, ul)
 import Html.Styled.Attributes exposing (css, href)
-import Skin.Global exposing (darkPurple, mapImageMulti, pink, purple, white)
+import Skin.Global exposing (colorAccent, colorAccentDark, colorSecondary, colorWhite, mapImageMulti)
 import Theme.GlobalLayout exposing (borderTransition, colorTransition, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.RegionSelector
 
@@ -147,8 +147,8 @@ areaDistrictString address =
 partnerAreaTagSpan : List (Html.Styled.Attribute msg) -> List (Html msg) -> Html msg
 partnerAreaTagSpan =
     styled span
-        [ backgroundColor darkPurple
-        , color pink
+        [ backgroundColor colorAccentDark
+        , color colorSecondary
         , display inlineBlock
         , marginLeft (rem 0.5)
         , padding2 (rem 0.25) (rem 0.5)
@@ -167,7 +167,7 @@ partnerAreaTagSpan =
 partnersListTitleStyle : Style
 partnersListTitleStyle =
     batch
-        [ color white
+        [ color colorWhite
         , textTransform uppercase
         , fontSize (rem 1.2)
         , letterSpacing (px 1.9)
@@ -192,9 +192,9 @@ listItemStyle =
         [ withMediaCanHover
             [ hover
                 [ descendants
-                    [ typeSelector "a" [ color pink ]
-                    , typeSelector "h4" [ color pink ]
-                    , typeSelector "div" [ borderBottomColor white ]
+                    [ typeSelector "a" [ color colorSecondary ]
+                    , typeSelector "h4" [ color colorSecondary ]
+                    , typeSelector "div" [ borderBottomColor colorWhite ]
                     ]
                 ]
             ]
@@ -210,7 +210,7 @@ partnerTopRowStyle =
         , justifyContent spaceBetween
         , alignItems flexEnd
         , padding2 (rem 0.5) (rem 0)
-        , borderBottomColor pink
+        , borderBottomColor colorSecondary
         , borderBottomWidth (px 2)
         , borderBottomStyle solid
         , withMediaTabletLandscapeUp [ padding2 (rem 0.75) (rem 0) ]
@@ -232,7 +232,7 @@ partnerLink : Style
 partnerLink =
     batch
         [ textDecoration none
-        , color white
+        , color colorWhite
         , transition [ colorTransition ]
         ]
 
@@ -242,7 +242,7 @@ partnerNameStyle =
     batch
         [ fontSize (rem 1.2)
         , fontStyle italic
-        , color white
+        , color colorWhite
         , transition [ colorTransition ]
         , withMediaTabletPortraitUp [ fontSize (rem 1.5) ]
         ]
@@ -270,5 +270,5 @@ featurePlaceholderStyle =
         [ textAlign center
         , fontWeight bold
         , marginBottom (rem 2)
-        , backgroundColor purple
+        , backgroundColor colorAccent
         ]

--- a/src/Theme/PageFooter.elm
+++ b/src/Theme/PageFooter.elm
@@ -9,7 +9,7 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, button, div, footer, form, img, input, label, li, nav, p, span, text, ul)
 import Html.Styled.Attributes exposing (action, alt, attribute, css, for, href, id, method, name, placeholder, src, target, type_, value)
 import List exposing (append, concat)
-import Skin.Global exposing (darkBlue, darkPurple, pink, pinkButtonOnDarkBackgroundStyle, smallInlineTitleStyle, textInputStyle, white)
+import Skin.Global exposing (colorAccentDark, colorPrimary, colorSecondary, colorWhite, secondaryButtonOnDarkBackgroundStyle, smallInlineTitleStyle, textInputStyle)
 import Theme.GlobalLayout exposing (colorTransition, withMediaCanHover, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Logo
 import Time
@@ -116,7 +116,7 @@ viewPageFooterSignup =
             , input [ type_ "hidden", id "6735a", name "l", value "6735a059-52dd-4843-b76c-4d2b210462d3" ] []
             , button
                 [ type_ "submit"
-                , css [ pinkButtonOnDarkBackgroundStyle, signupButtonStyle ]
+                , css [ secondaryButtonOnDarkBackgroundStyle, signupButtonStyle ]
                 ]
                 [ text (t FooterSignupButton) ]
             ]
@@ -125,7 +125,7 @@ viewPageFooterSignup =
 
 viewPageFooterInfo : String -> List String -> Html msg
 viewPageFooterInfo title info =
-    div [ css [ pinkBlockStyle ] ]
+    div [ css [ secondaryBlockStyle ] ]
         (append
             [ p [ css [ infoParagraphStyle, fontWeight (int 700) ] ]
                 [ text title
@@ -153,7 +153,7 @@ viewPageFooterSocial =
 
 viewPageFooterCredit : Time.Posix -> String -> List { name : String, link : String, text : String } -> Html msg
 viewPageFooterCredit time creditTitle creditList =
-    div [ css [ pinkBlockStyle ] ]
+    div [ css [ secondaryBlockStyle ] ]
         [ p [ css [ infoParagraphStyle, fontWeight (int 700), marginTop (rem 0) ] ]
             [ text creditTitle ]
         , p
@@ -183,7 +183,7 @@ viewPageFooterCreditItem creditItem =
 footerStyle : Style
 footerStyle =
     batch
-        [ backgroundColor darkBlue
+        [ backgroundColor colorPrimary
         , marginTop (rem 2)
         , displayFlex
         , flexDirection column
@@ -202,14 +202,14 @@ footerTopSectionStyle =
             , justifyContent spaceBetween
             , alignItems center
             ]
-        , backgroundColor pink
+        , backgroundColor colorSecondary
         ]
 
 
 footerMiddleSectionStyle : Style
 footerMiddleSectionStyle =
     batch
-        [ backgroundColor darkBlue
+        [ backgroundColor colorPrimary
         , padding2 (rem 1) (rem 0)
         , property "display" "grid"
         , property "grid-template-columns" "1fr"
@@ -234,14 +234,14 @@ footerMiddleSectionStyle =
 footerBottomSectionStyle : Style
 footerBottomSectionStyle =
     batch
-        [ backgroundColor pink ]
+        [ backgroundColor colorSecondary ]
 
 
 footerLogoStyle : Style
 footerLogoStyle =
     batch
         [ padding (rem 1)
-        , backgroundColor pink
+        , backgroundColor colorSecondary
         , textAlign center
         ]
 
@@ -260,7 +260,7 @@ footerLogoImageStyle =
 createdByStyle : Style
 createdByStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , padding (rem 1)
         , boxSizing borderBox
         , withMediaSmallDesktopUp
@@ -277,17 +277,17 @@ createdByStyle =
 socialStyle : Style
 socialStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , padding (rem 1)
         , boxSizing borderBox
         ]
 
 
-pinkBlockStyle : Style
-pinkBlockStyle =
+secondaryBlockStyle : Style
+secondaryBlockStyle =
     batch
-        [ color darkBlue
-        , backgroundColor pink
+        [ color colorPrimary
+        , backgroundColor colorSecondary
         , padding (rem 1)
         , boxSizing borderBox
         ]
@@ -297,7 +297,7 @@ subheadStyle : Style
 subheadStyle =
     batch
         [ smallInlineTitleStyle
-        , color white
+        , color colorWhite
         , display block
         , margin4 (rem 0.5) (rem 0) (rem 1) (rem 0)
         , fontSize (rem 1.2)
@@ -308,7 +308,7 @@ subheadStyle =
 navStyle : Style
 navStyle =
     batch
-        [ backgroundColor pink
+        [ backgroundColor colorSecondary
         , padding4 (rem 1) (rem 1) (rem 3) (rem 1)
         , marginBottom (rem 1)
         , withMediaTabletPortraitUp [ marginBottom (rem 0), padding (rem 1), maxWidth (pct 55) ]
@@ -335,10 +335,10 @@ navListItemStyle =
 navListItemLinkStyle : Style
 navListItemLinkStyle =
     batch
-        [ color darkBlue
+        [ color colorPrimary
         , textDecoration none
         , transition [ Css.Transitions.color 300 ]
-        , withMediaCanHover [ hover [ color white ] ]
+        , withMediaCanHover [ hover [ color colorWhite ] ]
         ]
 
 
@@ -360,7 +360,7 @@ logoListItemStyle =
         , flexDirection column
         , textAlign center
         , after
-            [ color white
+            [ color colorWhite
             , property "content" "\"+\""
             , display block
             , fontSize (rem 2)
@@ -410,7 +410,7 @@ formStyle =
     batch
         [ padding (rem 1)
         , boxSizing borderBox
-        , color white
+        , color colorWhite
         , marginBottom (rem 1)
         ]
 
@@ -436,7 +436,7 @@ formInputStyle =
         , textAlign center
         , width (pct 100)
         , fontSize (rem 1.2)
-        , pseudoElement "placeholder" [ color white ]
+        , pseudoElement "placeholder" [ color colorWhite ]
         , withMediaTabletPortraitUp [ margin4 (rem 0) (rem 1) (rem 0) (rem 0) ]
         ]
 
@@ -468,10 +468,10 @@ infoParagraphStyle =
 creditLinkStyle : Style
 creditLinkStyle =
     batch
-        [ color darkBlue
-        , withMediaCanHover [ hover [ color darkPurple ] ]
-        , focus [ color white ]
-        , active [ color white ]
+        [ color colorPrimary
+        , withMediaCanHover [ hover [ color colorAccentDark ] ]
+        , focus [ color colorWhite ]
+        , active [ color colorWhite ]
         , transition [ colorTransition ]
         ]
 

--- a/src/Theme/PageFooter.elm
+++ b/src/Theme/PageFooter.elm
@@ -85,7 +85,7 @@ viewPageFooterLogos =
             [ li [ css [ logoListItemStyle ] ]
                 [ a [ href (t GeeksForSocialChangeHomeUrl), target "_blank", css [ Theme.Logo.logoParentStyle ] ] [ Theme.Logo.viewGFSC ] ]
             , li [ css [ logoListItemStyle ] ]
-                [ a [ href (t GenderedIntelligenceHomeUrl), target "_blank", css [ logoGIStyle ], attribute "aria-label" (t GenderedIntelligenceLogoTxt) ] [] ]
+                [ a [ href (t PartnerOrganisationHomeUrl), target "_blank", css [ logoGIStyle ], attribute "aria-label" (t PartnerOrganisationLogoTxt) ] [] ]
             ]
         ]
 

--- a/src/Theme/PageHeader.elm
+++ b/src/Theme/PageHeader.elm
@@ -10,7 +10,7 @@ import Html.Styled.Attributes exposing (attribute, css, href)
 import Html.Styled.Events exposing (onClick)
 import Messages exposing (Msg(..))
 import Route exposing (Route)
-import Skin.Global exposing (darkBlue, pink, white)
+import Skin.Global exposing (colorPrimary, colorSecondary, colorWhite)
 import Theme.GlobalLayout exposing (screenReaderOnly, withMediaCanHover, withMediaTabletPortraitUp)
 import Theme.Logo
 import UrlPath exposing (UrlPath)
@@ -143,7 +143,7 @@ headerStyle =
         [ displayFlex
         , flexDirection columnReverse
         , textAlign center
-        , color white
+        , color colorWhite
         , paddingBottom (rem 1)
         ]
 
@@ -168,7 +168,7 @@ barStyle : Style
 barStyle =
     batch
         [ withMediaTabletPortraitUp
-            [ backgroundColor pink
+            [ backgroundColor colorSecondary
             , alignItems center
             ]
         ]
@@ -198,7 +198,7 @@ menuButtonButtonStyle =
 buttonTextStyle : Style
 buttonTextStyle =
     batch
-        [ color white
+        [ color colorWhite
         , marginRight (rem 0.5)
         ]
 
@@ -206,7 +206,7 @@ buttonTextStyle =
 buttonCrossStyle : Style
 buttonCrossStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , fontSize (rem 4)
         , fontWeight lighter
         , display block
@@ -232,7 +232,7 @@ navigationListStyle =
 navigationListItemStyle : Style
 navigationListItemStyle =
     batch
-        [ backgroundColor pink
+        [ backgroundColor colorSecondary
         , display block
         , padding (rem 1)
         , boxSizing borderBox
@@ -249,15 +249,15 @@ navigationLinkStyle : Style
 navigationLinkStyle =
     batch
         [ fontWeight (int 600)
-        , color darkBlue
+        , color colorPrimary
         , textDecoration none
         , display block
         , borderBottomWidth (rem 0.2)
         , borderBottomStyle solid
-        , borderBottomColor pink
-        , withMediaCanHover [ hover [ color white ] ]
+        , borderBottomColor colorSecondary
+        , withMediaCanHover [ hover [ color colorWhite ] ]
         , transition [ Css.Transitions.border 300, Css.Transitions.color 300 ]
-        , withMediaTabletPortraitUp [ withMediaCanHover [ hover [ borderBottomColor darkBlue ] ] ]
+        , withMediaTabletPortraitUp [ withMediaCanHover [ hover [ borderBottomColor colorPrimary ] ] ]
         ]
 
 
@@ -265,11 +265,11 @@ navigationCurrentStyle : Style
 navigationCurrentStyle =
     batch
         [ fontWeight (int 600)
-        , color darkBlue
+        , color colorPrimary
         , textDecoration none
         , display block
         , withMediaTabletPortraitUp
-            [ borderBottomColor darkBlue
+            [ borderBottomColor colorPrimary
             , borderBottomWidth (rem 0.2)
             , borderBottomStyle solid
             ]
@@ -280,13 +280,13 @@ navigationLinkCurrentCategoryStyle : Style
 navigationLinkCurrentCategoryStyle =
     batch
         [ fontWeight (int 600)
-        , color darkBlue
+        , color colorPrimary
         , textDecoration none
         , display block
-        , withMediaCanHover [ hover [ color white ] ]
+        , withMediaCanHover [ hover [ color colorWhite ] ]
         , transition [ Css.Transitions.border 300, Css.Transitions.color 300 ]
         , withMediaTabletPortraitUp
-            [ borderBottomColor darkBlue
+            [ borderBottomColor colorPrimary
             , borderBottomWidth (rem 0.2)
             , borderBottomStyle solid
             ]
@@ -307,10 +307,10 @@ askStyle =
 askButtonStyle : Style
 askButtonStyle =
     batch
-        [ backgroundColor white
+        [ backgroundColor colorWhite
         , borderBottomStyle none
         , padding (rem 1)
-        , withMediaCanHover [ hover [ color pink ] ]
+        , withMediaCanHover [ hover [ color colorSecondary ] ]
         , withMediaTabletPortraitUp
             [ padding4 (rem 0.375) (rem 1.25) (rem 0.5) (rem 1.25)
             , borderRadius (rem 0.3)

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -10,7 +10,7 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import List exposing (append)
 import Markdown.Block
 import Pages.Url
-import Skin.Global exposing (contentWrapperStyle, introTextLargeStyle, introTextSmallStyle, textBoxInvisibleStyle, textBoxPinkStyle, white)
+import Skin.Global exposing (colorWhite, contentWrapperStyle, introTextLargeStyle, introTextSmallStyle, textBoxInvisibleStyle, textBoxSecondaryStyle)
 import Theme.GlobalLayout exposing (contentContainerStyle, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
@@ -46,7 +46,7 @@ type alias BigText =
 
 
 type HeaderType
-    = PinkHeader
+    = SecondaryHeader
     | InvisibleHeader
     | AboutHeader
 
@@ -54,8 +54,8 @@ type HeaderType
 stringToHeaderType : Maybe String -> HeaderType
 stringToHeaderType maybeTypeString =
     case maybeTypeString of
-        Just "pink" ->
-            PinkHeader
+        Just "secondary" ->
+            SecondaryHeader
 
         Just "invisible" ->
             InvisibleHeader
@@ -64,10 +64,10 @@ stringToHeaderType maybeTypeString =
             AboutHeader
 
         Just _ ->
-            PinkHeader
+            SecondaryHeader
 
         Nothing ->
-            PinkHeader
+            SecondaryHeader
 
 
 pageMetaTags : { title : Key, description : Key, imageSrc : Maybe String } -> List Head.Tag
@@ -175,12 +175,12 @@ viewIntro bigText smallText =
         [ css
             (case smallText of
                 Nothing ->
-                    [ textBoxPinkStyle ]
+                    [ textBoxSecondaryStyle ]
 
                 Just _ ->
                     [ withMediaTabletPortraitUp
                         [ paddingTop (rem 1.5) ]
-                    , textBoxPinkStyle
+                    , textBoxSecondaryStyle
                     ]
             )
         ]
@@ -246,7 +246,7 @@ pageHeadingStyle =
     batch
         [ fontSize (rem 2.1)
         , outline none
-        , color white
+        , color colorWhite
         , fontStyle italic
         , fontWeight (int 500)
         , textAlign center

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -11,7 +11,7 @@ import Helpers.TransDate as TransDate
 import Html.Styled exposing (Html, button, div, img, li, text, ul)
 import Html.Styled.Attributes exposing (css, id, src)
 import Html.Styled.Events
-import Skin.Global exposing (darkBlue, darkPurple, pink, white)
+import Skin.Global exposing (colorAccentDark, colorPrimary, colorSecondary, colorWhite)
 import Task exposing (Task)
 import Theme.GlobalLayout exposing (backgroundColorTransition, borderTransition, colorTransition, maxMobile, maxTabletPortrait, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Time
@@ -287,30 +287,30 @@ paginationButtonStyle : Style
 paginationButtonStyle =
     batch
         [ borderStyle solid
-        , borderColor pink
+        , borderColor colorSecondary
         , borderWidth (px 2)
-        , color pink
+        , color colorSecondary
         , borderRadius (rem 0.3)
         , textAlign center
         , cursor pointer
         , withMediaCanHover
             [ hover
-                [ backgroundColor darkPurple
-                , color white
-                , borderColor white
+                [ backgroundColor colorAccentDark
+                , color colorWhite
+                , borderColor colorWhite
                 , descendants [ typeSelector "img" [ property "filter" "invert(1)" ] ]
                 ]
             ]
         , focus
-            [ backgroundColor white
-            , color darkBlue
-            , borderColor white
+            [ backgroundColor colorWhite
+            , color colorPrimary
+            , borderColor colorWhite
             , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
             ]
         , active
-            [ backgroundColor white
-            , color darkBlue
-            , borderColor white
+            [ backgroundColor colorWhite
+            , color colorPrimary
+            , borderColor colorWhite
             , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
             ]
         , transition [ colorTransition, borderTransition, backgroundColorTransition ]
@@ -321,7 +321,7 @@ paginationArrowButtonStyle : Style
 paginationArrowButtonStyle =
     batch
         [ paginationButtonStyle
-        , backgroundColor pink
+        , backgroundColor colorSecondary
         , margin4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 0)
         , paddingRight (rem 0.5)
         , withMediaSmallDesktopUp [ display none ]
@@ -336,7 +336,7 @@ paginationArrowButtonRightStyle : Style
 paginationArrowButtonRightStyle =
     batch
         [ paginationButtonStyle
-        , backgroundColor pink
+        , backgroundColor colorSecondary
         , margin4 (rem 0.25) (rem 0) (rem 0.25) (rem 0.25)
         , paddingLeft (rem 0.5)
         , withMediaSmallDesktopUp [ display none ]
@@ -422,7 +422,7 @@ paginationButtonListItemButtonStyle =
         , fontWeight (int 600)
         , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
         , width (px buttonWidthMobile)
-        , backgroundColor darkBlue
+        , backgroundColor colorPrimary
         , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
         , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
         ]
@@ -436,8 +436,8 @@ paginationButtonListItemButtonActiveStyle =
         , fontWeight (int 600)
         , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
         , width (px buttonWidthMobile)
-        , backgroundColor pink
-        , color darkBlue
+        , backgroundColor colorSecondary
+        , color colorPrimary
         , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
         , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
         ]

--- a/src/Theme/RegionSelector.elm
+++ b/src/Theme/RegionSelector.elm
@@ -9,7 +9,7 @@ import Data.PlaceCal.Partners
 import Html.Styled exposing (Html, button, div, li, text, ul)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events
-import Skin.Global exposing (darkBlue, darkPurple, white)
+import Skin.Global exposing (colorAccentDark, colorPrimary, colorWhite)
 import Theme.GlobalLayout exposing (backgroundColorTransition, borderTransition, colorTransition, withMediaCanHover, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
@@ -118,30 +118,30 @@ regionSelectorButtonStyle : Style
 regionSelectorButtonStyle =
     batch
         [ borderStyle solid
-        , borderColor white
+        , borderColor colorWhite
         , borderWidth (px 2)
-        , color white
+        , color colorWhite
         , borderRadius (rem 0.3)
         , textAlign center
         , cursor pointer
         , withMediaCanHover
             [ hover
-                [ backgroundColor darkPurple
-                , color white
-                , borderColor white
+                [ backgroundColor colorAccentDark
+                , color colorWhite
+                , borderColor colorWhite
                 , descendants [ typeSelector "img" [ property "filter" "invert(1)" ] ]
                 ]
             ]
         , focus
-            [ backgroundColor white
-            , color darkBlue
-            , borderColor white
+            [ backgroundColor colorWhite
+            , color colorPrimary
+            , borderColor colorWhite
             , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
             ]
         , active
-            [ backgroundColor white
-            , color darkBlue
-            , borderColor white
+            [ backgroundColor colorWhite
+            , color colorPrimary
+            , borderColor colorWhite
             , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
             ]
         , transition [ colorTransition, borderTransition, backgroundColorTransition ]
@@ -189,7 +189,7 @@ regionSelectorButtonListItemButtonStyle =
         , fontWeight (int 600)
         , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
         , width (px buttonWidthMobile)
-        , backgroundColor darkBlue
+        , backgroundColor colorPrimary
         , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
         , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
         ]
@@ -203,8 +203,8 @@ regionSelectorButtonListItemButtonActiveStyle =
         , fontWeight (int 600)
         , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
         , width (px buttonWidthMobile)
-        , backgroundColor white
-        , color darkBlue
+        , backgroundColor colorWhite
+        , color colorPrimary
         , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
         , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
         ]

--- a/src/Theme/TransMarkdown.elm
+++ b/src/Theme/TransMarkdown.elm
@@ -8,7 +8,7 @@ import Markdown.Block
 import Markdown.Html
 import Markdown.Parser
 import Markdown.Renderer
-import Skin.Global exposing (linkStyle, pink)
+import Skin.Global exposing (colorSecondary, linkStyle)
 import Theme.GlobalLayout exposing (withMediaSmallDesktopUp, withMediaTabletLandscapeUp)
 
 
@@ -259,7 +259,7 @@ headerStyle =
     batch
         [ marginBlockStart (em 1)
         , marginBlockEnd (em 1)
-        , color pink
+        , color colorSecondary
         , lineHeight (em 1.2)
         ]
 
@@ -320,7 +320,7 @@ ulLiStyle =
             ]
         , before
             [ property "content" "\"\\25A0\""
-            , color pink
+            , color colorSecondary
             , fontSize (em 1.5)
             , position absolute
             , left (rem 0)

--- a/theme/Copy/Text.elm
+++ b/theme/Copy/Text.elm
@@ -1,4 +1,4 @@
-module Copy.Text exposing (isValidUrl, t, urlToDisplay)
+module Copy.Text exposing (t)
 
 import Constants exposing (canonicalUrl)
 import Copy.Keys exposing (Key(..), Prefix(..))
@@ -18,7 +18,7 @@ t key =
         SiteStrapline ->
             "My strapline"
 
-        TransDimensionDescription ->
+        CommunityDescription ->
             -- Note this is also in content/about/main.md
             -- If they should remain in sync, we should remove from there
             "The Trans Dimension is an online community hub connecting trans communities in London and Manchester. We collate news, events and services by and for trans people."
@@ -29,10 +29,10 @@ t key =
         GeeksForSocialChangeHomeUrl ->
             "https://gfsc.studio/"
 
-        GenderedIntelligenceHomeUrl ->
+        PartnerOrganisationHomeUrl ->
             "https://genderedintelligence.co.uk/"
 
-        GenderedIntelligenceLogoTxt ->
+        PartnerOrganisationLogoTxt ->
             "Gendered Intelligence"
 
         GoogleMapSearchUrl address ->
@@ -146,7 +146,7 @@ t key =
             "Trusted, accessible, trans-friendly spaces. Always expanding."
 
         IndexIntroMessage ->
-            t TransDimensionDescription
+            t CommunityDescription
 
         IndexIntroButtonText ->
             "See what's on"
@@ -168,7 +168,7 @@ t key =
             "About"
 
         AboutMetaDescription ->
-            t TransDimensionDescription
+            t CommunityDescription
 
         --- Events Page
         EventsTitle ->
@@ -377,37 +377,3 @@ t key =
 
         ErrorButtonText ->
             "Back to home"
-
-
-urlRecombiner : Maybe Url.Url -> String
-urlRecombiner urlRecord =
-    case urlRecord of
-        Just url ->
-            url.host ++ url.path ++ Maybe.withDefault "" url.query ++ Maybe.withDefault "" url.fragment
-
-        Nothing ->
-            ""
-
-
-chompTrailingUrlSlash : String -> String
-chompTrailingUrlSlash urlString =
-    if String.endsWith "/" urlString then
-        String.dropRight 1 urlString
-
-    else
-        urlString
-
-
-urlToDisplay : String -> String
-urlToDisplay url =
-    Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
-
-
-isValidUrl : String -> Bool
-isValidUrl urlString =
-    case Url.fromString urlString of
-        Just url ->
-            url.protocol == Url.Https
-
-        Nothing ->
-            False

--- a/theme/Skin/Global.elm
+++ b/theme/Skin/Global.elm
@@ -1,4 +1,4 @@
-module Skin.Global exposing (contentWrapperStyle, darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, darkBlueRgbColor, darkPurple, globalStyles, hrStyle, introTextLargeStyle, introTextSmallStyle, linkStyle, mapImage, mapImageMulti, normalFirstParagraphStyle, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, pinkButtonOnLightBackgroundStyle, pinkRgbColor, purple, smallFloatingTitleStyle, smallInlineTitleStyle, textBoxInvisibleStyle, textBoxPinkStyle, textInputErrorStyle, textInputStyle, viewBackButton, viewCheckbox, white, whiteButtonStyle)
+module Skin.Global exposing (colorAccent, colorAccentDark, colorPrimary, colorPrimaryRgb, colorSecondary, colorSecondaryHexString, colorSecondaryRgb, colorWhite, contentWrapperStyle, globalStyles, hrStyle, introTextLargeStyle, introTextSmallStyle, linkStyle, mapImage, mapImageMulti, normalFirstParagraphStyle, primaryBackgroundStyle, primaryButtonStyle, secondaryBackgroundStyle, secondaryButtonOnDarkBackgroundStyle, secondaryButtonOnLightBackgroundStyle, smallFloatingTitleStyle, smallInlineTitleStyle, textBoxInvisibleStyle, textBoxSecondaryStyle, textInputErrorStyle, textInputStyle, viewBackButton, viewCheckbox, whiteButtonStyle)
 
 import Color
 import Css exposing (Color, Style, absolute, active, alignItems, auto, backgroundColor, backgroundImage, backgroundRepeat, backgroundSize, batch, block, borderBottomColor, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderRadius, borderStyle, borderWidth, bottom, boxSizing, calc, center, color, cursor, display, displayFlex, em, firstChild, fitContent, flexDirection, focus, fontFamilies, fontSize, fontStyle, fontWeight, height, hex, hidden, hover, inlineBlock, int, italic, justifyContent, left, letterSpacing, lineHeight, margin, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxContent, maxWidth, minus, none, outline, overflow, padding, padding2, padding4, paddingBottom, paddingLeft, paddingRight, pct, pointer, position, property, px, relative, rem, repeat, row, sansSerif, solid, textAlign, textDecoration, textTransform, top, uppercase, url, width, zero)
@@ -12,45 +12,54 @@ import Theme.GlobalLayout exposing (withMediaCanHover, withMediaMediumDesktopUp,
 
 
 -- Brand colours
+-- Primary and Secondary are used as text and background colours on each other.
+-- White is also used as text and background
+-- So make sure there is sufficient contrast between the three in all combinations.
+-- Supply both RGB and Hex values for primary and secondary
 
 
-darkBlueRgbColor : Color.Color
-darkBlueRgbColor =
+colorPrimaryRgb : Color.Color
+colorPrimaryRgb =
     Color.rgb255 4 15 57
 
 
-pinkRgbColor : Color.Color
-pinkRgbColor =
+colorSecondaryRgb : Color.Color
+colorSecondaryRgb =
     Color.rgb255 255 122 167
 
 
-darkBlue : Color
-darkBlue =
+colorSecondaryHexString : String
+colorSecondaryHexString =
+    "FF7AA7"
+
+
+colorPrimary : Color
+colorPrimary =
     hex "040F39"
 
 
-pink : Color
-pink =
-    hex "FF7AA7"
+colorSecondary : Color
+colorSecondary =
+    hex colorSecondaryHexString
 
 
-lightPink : Color
-lightPink =
+colorSecondaryLight : Color
+colorSecondaryLight =
     hex "FFBCD3"
 
 
-purple : Color
-purple =
+colorAccent : Color
+colorAccent =
     hex "814470"
 
 
-darkPurple : Color
-darkPurple =
+colorAccentDark : Color
+colorAccentDark =
     hex "432955"
 
 
-white : Color
-white =
+colorWhite : Color
+colorWhite =
     hex "FFFFFF"
 
 
@@ -61,71 +70,71 @@ white =
 viewBackButton : String -> String -> Html msg
 viewBackButton link buttonText =
     p [ css [ Theme.GlobalLayout.backButtonStyle ] ]
-        [ a [ href link, css [ darkBlueButtonStyle ] ] [ text buttonText ] ]
+        [ a [ href link, css [ primaryButtonStyle ] ] [ text buttonText ] ]
 
 
 whiteButtonStyle : Style
 whiteButtonStyle =
     batch
         [ Theme.GlobalLayout.baseButtonStyle
-        , backgroundColor white
-        , color darkBlue
-        , borderColor white
-        , withMediaCanHover [ hover [ backgroundColor purple, color white ] ]
-        , active [ backgroundColor darkBlue, color white ]
-        , focus [ backgroundColor darkBlue, color white ]
+        , backgroundColor colorWhite
+        , color colorPrimary
+        , borderColor colorWhite
+        , withMediaCanHover [ hover [ backgroundColor colorAccent, color colorWhite ] ]
+        , active [ backgroundColor colorPrimary, color colorWhite ]
+        , focus [ backgroundColor colorPrimary, color colorWhite ]
         ]
 
 
-darkBlueButtonStyle : Style
-darkBlueButtonStyle =
+primaryButtonStyle : Style
+primaryButtonStyle =
     batch
         [ Theme.GlobalLayout.baseButtonStyle
-        , backgroundColor darkBlue
-        , color white
-        , borderColor pink
-        , Theme.GlobalLayout.withMediaCanHover [ hover [ backgroundColor purple, color white, borderColor white ] ]
-        , active [ backgroundColor pink, color darkBlue, borderColor white ]
-        , focus [ backgroundColor pink, color darkBlue, borderColor white ]
+        , backgroundColor colorPrimary
+        , color colorWhite
+        , borderColor colorSecondary
+        , Theme.GlobalLayout.withMediaCanHover [ hover [ backgroundColor colorAccent, color colorWhite, borderColor colorWhite ] ]
+        , active [ backgroundColor colorSecondary, color colorPrimary, borderColor colorWhite ]
+        , focus [ backgroundColor colorSecondary, color colorPrimary, borderColor colorWhite ]
         ]
 
 
-pinkButtonOnDarkBackgroundStyle : Style
-pinkButtonOnDarkBackgroundStyle =
+secondaryButtonOnDarkBackgroundStyle : Style
+secondaryButtonOnDarkBackgroundStyle =
     batch
         [ Theme.GlobalLayout.baseButtonStyle
-        , backgroundColor pink
-        , color darkBlue
-        , borderColor pink
-        , withMediaCanHover [ hover [ backgroundColor lightPink, borderColor lightPink ] ]
-        , active [ backgroundColor white, borderColor white ]
-        , focus [ backgroundColor white, borderColor white ]
+        , backgroundColor colorSecondary
+        , color colorPrimary
+        , borderColor colorSecondary
+        , withMediaCanHover [ hover [ backgroundColor colorSecondaryLight, borderColor colorSecondaryLight ] ]
+        , active [ backgroundColor colorWhite, borderColor colorWhite ]
+        , focus [ backgroundColor colorWhite, borderColor colorWhite ]
         ]
 
 
-pinkButtonOnLightBackgroundStyle : Style
-pinkButtonOnLightBackgroundStyle =
+secondaryButtonOnLightBackgroundStyle : Style
+secondaryButtonOnLightBackgroundStyle =
     batch
         [ Theme.GlobalLayout.baseButtonStyle
-        , backgroundColor pink
-        , color darkBlue
-        , borderColor pink
-        , withMediaCanHover [ hover [ backgroundColor purple, borderColor white, color white ] ]
-        , active [ backgroundColor darkBlue, borderColor white, color white ]
-        , focus [ backgroundColor darkBlue, borderColor white, color white ]
+        , backgroundColor colorSecondary
+        , color colorPrimary
+        , borderColor colorSecondary
+        , withMediaCanHover [ hover [ backgroundColor colorAccent, borderColor colorWhite, color colorWhite ] ]
+        , active [ backgroundColor colorPrimary, borderColor colorWhite, color colorWhite ]
+        , focus [ backgroundColor colorPrimary, borderColor colorWhite, color colorWhite ]
         ]
 
 
-pinkBackgroundStyle : Style
-pinkBackgroundStyle =
-    backgroundColor pink
+secondaryBackgroundStyle : Style
+secondaryBackgroundStyle =
+    backgroundColor colorSecondary
 
 
-darkBlueBackgroundStyle : Style
-darkBlueBackgroundStyle =
+primaryBackgroundStyle : Style
+primaryBackgroundStyle =
     batch
-        [ backgroundColor darkBlue
-        , borderColor pink
+        [ backgroundColor colorPrimary
+        , borderColor colorSecondary
         , borderStyle solid
         , borderWidth (px 1)
         ]
@@ -154,7 +163,7 @@ smallFloatingTitleStyle =
         , width (calc (pct 100) minus (rem 2))
         , left (rem 1)
         , fontSize (rem 1.2)
-        , color white
+        , color colorWhite
         ]
 
 
@@ -176,8 +185,8 @@ contentWrapperStyle : Style
 contentWrapperStyle =
     batch
         [ borderRadius (rem 0.3)
-        , backgroundColor darkBlue
-        , borderColor pink
+        , backgroundColor colorPrimary
+        , borderColor colorSecondary
         , borderStyle solid
         , borderWidth (px 1)
         ]
@@ -196,25 +205,25 @@ textBoxStyle =
         ]
 
 
-textBoxPinkStyle : Style
-textBoxPinkStyle =
+textBoxSecondaryStyle : Style
+textBoxSecondaryStyle =
     batch
         [ textBoxStyle
-        , backgroundColor pink
-        , color darkBlue
+        , backgroundColor colorSecondary
+        , color colorPrimary
         ]
 
 
 textBoxInvisibleStyle : Style
 textBoxInvisibleStyle =
     batch
-        [ backgroundColor darkBlue
-        , color pink
+        [ backgroundColor colorPrimary
+        , color colorSecondary
         , textBoxStyle
         , paddingBottom (rem 0)
         , descendants
-            [ typeSelector "h3" [ batch [ color pink, Theme.GlobalLayout.withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
-            , typeSelector "p" [ batch [ color pink, Theme.GlobalLayout.withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
+            [ typeSelector "h3" [ batch [ color colorSecondary, Theme.GlobalLayout.withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
+            , typeSelector "p" [ batch [ color colorSecondary, Theme.GlobalLayout.withMediaTabletLandscapeUp [ margin4 (rem 2) auto (rem 0) auto ] ] ]
             ]
         ]
 
@@ -222,7 +231,7 @@ textBoxInvisibleStyle =
 hrStyle : Style
 hrStyle =
     batch
-        [ borderColor pink
+        [ borderColor colorSecondary
         , borderStyle solid
         , borderWidth (px 0.5)
         , margin2 (rem 2) (rem 0)
@@ -264,12 +273,12 @@ introTextSmallStyle =
 linkStyle : Style
 linkStyle =
     batch
-        [ color white
-        , borderBottomColor pink
+        [ color colorWhite
+        , borderBottomColor colorSecondary
         , borderBottomStyle solid
         , borderBottomWidth (px 1)
         , textDecoration none
-        , withMediaCanHover [ hover [ color pink, borderBottomColor white ] ]
+        , withMediaCanHover [ hover [ color colorSecondary, borderBottomColor colorWhite ] ]
         , transition [ Theme.GlobalLayout.borderTransition, Theme.GlobalLayout.colorTransition ]
         ]
 
@@ -326,15 +335,15 @@ viewCheckbox boxId labelText checkedValue update =
 textInputStyle : Style
 textInputStyle =
     batch
-        [ backgroundColor darkBlue
-        , borderColor pink
+        [ backgroundColor colorPrimary
+        , borderColor colorSecondary
         , borderWidth (px 2)
         , borderStyle solid
         , borderRadius (rem 0.3)
         , padding2 (rem 0.5) (rem 1)
-        , color white
+        , color colorWhite
         , outline none
-        , focus [ borderColor white ]
+        , focus [ borderColor colorWhite ]
         ]
 
 
@@ -342,16 +351,16 @@ textInputErrorStyle : Style
 textInputErrorStyle =
     batch
         [ textInputStyle
-        , backgroundColor pink
-        , color darkBlue
-        , borderColor white
+        , backgroundColor colorSecondary
+        , color colorPrimary
+        , borderColor colorWhite
         ]
 
 
 checkboxLabelStyle : Style
 checkboxLabelStyle =
     batch
-        [ color pink
+        [ color colorSecondary
         , fontWeight (int 500)
         , displayFlex
         , flexDirection row
@@ -362,7 +371,7 @@ checkboxLabelStyle =
         , cursor pointer
         , maxWidth fitContent
         , Theme.GlobalLayout.withMediaTabletPortraitUp [ maxWidth (pct 100) ]
-        , focus [ color white ]
+        , focus [ color colorWhite ]
         ]
 
 
@@ -370,7 +379,7 @@ checkboxLabelCheckedStyle : Style
 checkboxLabelCheckedStyle =
     batch
         [ checkboxLabelStyle
-        , color white
+        , color colorWhite
         ]
 
 
@@ -384,13 +393,13 @@ checkboxStyle =
         , height (em 1.25)
         , margin (em 0.75)
         , padding (em 0.75)
-        , backgroundColor darkBlue
-        , borderColor pink
+        , backgroundColor colorPrimary
+        , borderColor colorSecondary
         , borderWidth (px 2)
         , borderStyle solid
         , cursor pointer
         , Css.checked
-            [ backgroundColor pink
+            [ backgroundColor colorSecondary
             , borderRadius (em 1)
             ]
         ]
@@ -407,8 +416,8 @@ globalStyles : Html msg
 globalStyles =
     global
         [ typeSelector "body"
-            [ backgroundColor darkBlue
-            , color white
+            [ backgroundColor colorPrimary
+            , color colorWhite
             , fontFamilies [ "covik-sans", sansSerif.value ]
             , fontWeight (int 400)
             , backgroundImage (url "/images/backgrounds/starfield-small-800.png")
@@ -418,16 +427,16 @@ globalStyles =
             , Theme.GlobalLayout.withMediaTabletLandscapeUp [ backgroundImage (url "/images/backgrounds/starfield-medium-1080.png"), backgroundSize (px 1080) ]
             ]
         , typeSelector "h1"
-            [ color darkBlue
+            [ color colorPrimary
             ]
         , typeSelector "h2"
-            [ color darkBlue
+            [ color colorPrimary
             ]
         , typeSelector "h3"
-            [ color darkBlue
+            [ color colorPrimary
             ]
         , typeSelector "h4"
-            [ color darkBlue
+            [ color colorPrimary
             ]
         , typeSelector "b"
             [ fontWeight (int 700)


### PR DESCRIPTION
Fixes #6

## Description

- Rename colors by purpose rather than hue
- Rename copy keys to be agnostic of community
- Move Copy utilities out of `theme/Copy/Text` into `Copy/Utils`
